### PR TITLE
Bump Flutter to 3.22.0, bump dependencies

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,4 +1,3 @@
 {
-  "flutter": "3.19.5",
-  "flavors": {}
+  "flutter": "3.22.0"
 }

--- a/.github/workflows/pr-ci-app-linux-appimage-x64.yml
+++ b/.github/workflows/pr-ci-app-linux-appimage-x64.yml
@@ -58,7 +58,7 @@ jobs:
       uses: baptiste0928/cargo-install@v3
       with:
         crate: flutter_rust_bridge_codegen
-        version: "2.0.0-dev.33"
+        version: "2.0.0-dev.34"
 
     - name: Install lddtree
       uses: baptiste0928/cargo-install@v3

--- a/.github/workflows/pr-ci-app-win-x64.yml
+++ b/.github/workflows/pr-ci-app-win-x64.yml
@@ -72,7 +72,7 @@ jobs:
       uses: baptiste0928/cargo-install@v3
       with:
         crate: flutter_rust_bridge_codegen
-        version: "2.0.0-dev.33"
+        version: "2.0.0-dev.34"
         args: --target x86_64-pc-windows-msvc
 
     - name: Install Dependencies

--- a/.github/workflows/release-linux-appimage-x64.yml
+++ b/.github/workflows/release-linux-appimage-x64.yml
@@ -61,7 +61,7 @@ jobs:
       uses: baptiste0928/cargo-install@v3
       with:
         crate: flutter_rust_bridge_codegen
-        version: "2.0.0-dev.33"
+        version: "2.0.0-dev.34"
 
     - name: Install lddtree
       uses: baptiste0928/cargo-install@v3

--- a/.github/workflows/release-macos-x64.yml
+++ b/.github/workflows/release-macos-x64.yml
@@ -62,7 +62,7 @@ jobs:
       uses: baptiste0928/cargo-install@v3
       with:
         crate: flutter_rust_bridge_codegen
-        version: "2.0.0-dev.33"
+        version: "2.0.0-dev.34"
 
     - name: Install flutter_distributor
       run: dart pub global activate flutter_distributor

--- a/.github/workflows/release-win-x64.yml
+++ b/.github/workflows/release-win-x64.yml
@@ -75,7 +75,7 @@ jobs:
       uses: baptiste0928/cargo-install@v3
       with:
         crate: flutter_rust_bridge_codegen
-        version: "2.0.0-dev.33"
+        version: "2.0.0-dev.34"
         args: --target x86_64-pc-windows-msvc
 
     # - name: Install flutter_distributor

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ app.*.map.json
 *.json.dart
 *.g.dart
 
+# l10n
+lib/l10n/generated/
+
 # flutter_rust_bridge
 frb_generated.*
 lib/src/**/*.dart

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
   "cmake.configureOnOpen": false,
-  "dart.flutterSdkPath": ".fvm/versions/3.19.5"
+  "dart.flutterSdkPath": ".fvm/versions/3.22.0"
 }

--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ Please note: Run all commands from the root folder of the repository, unless men
 Some additional notes:
 
 * If you have changed any code in the Dart or Rust project that could change the generated bridging code, you should re-run the `flutter_rust_bridge_codegen generate` or `just gen-bridge` command
+  * You can also run `flutter_rust_bridge_codegen generate --watch` or `just watch-bridge` to automatically regenerate the bridging code when you save a file
 * If you have changed any code related to JSON or TOML serialization, or MobX, you should re-run the `dart run build_runner build --delete-conflicting-outputs` or `just gen-code` command
+  * You can also run `dart run build_runner watch --delete-conflicting-outputs` or `just watch-code` to automatically regenerate the code when you save a file
 * If you have changed any code related to the localization, you should re-run the `flutter gen-l10n` of `just gen-l10n` command
 
 ### Adding a new screen using the VS Code extension Template

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Check the online documentation at [https://momentobooth.github.io/momentobooth/]
 ## Features
 
 * Single capture
-* Multi-capture
+* Multi-capture\
   Shoot 4 photos and then select the ones you like to for a collage of 1, 2, 3, or 4 photos
 * User friendly touch-centered interface
-* Photo printing
+* Photo printing\
   Lots of settings included to size and position your print well
 * Photo sharing using [`ffsend`](https://github.com/timvisee/ffsend) QR code
 * Theming with collage template images (background and foreground)

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Check the online documentation at [https://momentobooth.github.io/momentobooth/]
 ## Features
 
 * Single capture
-* Multi-capture  
+* Multi-capture
   Shoot 4 photos and then select the ones you like to for a collage of 1, 2, 3, or 4 photos
 * User friendly touch-centered interface
-* Photo printing  
+* Photo printing
   Lots of settings included to size and position your print well
 * Photo sharing using [`ffsend`](https://github.com/timvisee/ffsend) QR code
 * Theming with collage template images (background and foreground)
@@ -91,7 +91,7 @@ On Linux:
 All platforms:
 
 * `flutter_rust_bridge_codegen`
-  * Install using Cargo: `cargo install flutter_rust_bridge_codegen --version 2.0.0-dev.33`
+  * Install using Cargo: `cargo install flutter_rust_bridge_codegen --version 2.0.0-dev.34`
 * Flutter SDK 3.19.0+
   * Be sure that the `flutter` command is available globally as `flutter_rust_bridge_codegen` needs it\
     This is especially important when using Flutter SDK managers like `asdf` or `fvm`
@@ -104,12 +104,12 @@ For all tools, we support the latest versions.
 
 ### Build steps
 
-### Using `rps` (recommended)
+### Using `just` (recommended)
 
 Please note: This method expects global fvm and Dart installs to be available.
 
-1. Install `rps` using `dart pub global activate rps`
-2. Run `rps` from the root folder of the repository
+1. Install `just` (See [here](https://github.com/casey/just?tab=readme-ov-file#packages))
+2. Run `just` from the root folder of the repository
 
 ### Manually
 
@@ -123,9 +123,9 @@ Please note: Run all commands from the root folder of the repository, unless men
 
 Some additional notes:
 
-* If you have changed any code in the Dart or Rust project that could change the generated bridging code, you should re-run the `flutter_rust_bridge_codegen generate` or `rps generate rust_bridge` command
-* If you have changed any code related to JSON or TOML serialization, or MobX, you should re-run the `dart run build_runner build --delete-conflicting-outputs` or `rps generate build_runner_targets` command
-* If you have changed any code related to the localization, you should re-run the `flutter gen-l10n` of `rps generate l10n` command
+* If you have changed any code in the Dart or Rust project that could change the generated bridging code, you should re-run the `flutter_rust_bridge_codegen generate` or `just gen-bridge` command
+* If you have changed any code related to JSON or TOML serialization, or MobX, you should re-run the `dart run build_runner build --delete-conflicting-outputs` or `just gen-code` command
+* If you have changed any code related to the localization, you should re-run the `flutter gen-l10n` of `just gen-l10n` command
 
 ### Adding a new screen using the VS Code extension Template
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -9,6 +9,7 @@ analyzer:
     - 'lib/src/**/*.dart'
     - 'lib/views/custom_widgets/draggable_scrollbar_override.dart'
     - 'rust_builder/**/*'
+    - 'lib/l10n/generated/*'
 
 linter:
   # More info: https://dart.dev/tools/linter-rules

--- a/justfile
+++ b/justfile
@@ -3,7 +3,7 @@ default: install-cargo-expand install-bridge-codegen install-flutter get-deps ge
 set windows-shell := ["pwsh.exe", "-NoProfile", "-c"]
 
 ##
-# Getting started
+# Basic commands
 ##
 
 install-cargo-expand:
@@ -26,6 +26,16 @@ gen-code:
 
 gen-l10n:
   fvm flutter gen-l10n
+
+##
+# Watching
+##
+
+watch-bridge:
+  flutter_rust_bridge_codegen generate --watch
+
+watch-code:
+  fvm dart run build_runner watch --delete-conflicting-outputs
 
 ##
 # Building

--- a/justfile
+++ b/justfile
@@ -1,0 +1,72 @@
+default: install-cargo-expand install-bridge-codegen install-flutter get-deps gen-bridge gen-code gen-l10n
+
+set windows-shell := ["pwsh.exe", "-NoProfile", "-c"]
+
+##
+# Getting started
+##
+
+install-cargo-expand:
+  cargo install cargo-expand
+
+install-bridge-codegen:
+  cargo install flutter_rust_bridge_codegen@2.0.0-dev.34
+
+install-flutter:
+  fvm install -s --skip-pub-get
+
+get-deps:
+  fvm flutter pub get
+
+gen-bridge:
+  flutter_rust_bridge_codegen generate
+
+gen-code:
+  fvm dart run build_runner build --delete-conflicting-outputs
+
+gen-l10n:
+  fvm flutter gen-l10n
+
+##
+# Building
+##
+
+[windows]
+build-release:
+  fvm flutter build windows --release
+
+[linux]
+build-release:
+  fvm flutter build linux --release
+
+[macos]
+build-release:
+  fvm flutter build macos --release
+
+test:
+  fvm flutter test
+
+##
+# Docs
+##
+
+install-mdbook:
+  cargo install mdbook mdbook-mermaid mdbook-admonish
+
+build-docs:
+  mdbook build documentation
+
+##
+# Other commands
+##
+
+lint:
+  fvm flutter analyze
+
+show-outdated:
+  fvm flutter pub outdated
+  cd rust && cargo update -n
+
+upgrade-deps:
+  fvm flutter pub upgrade
+  cd rust && cargo update

--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,3 +1,6 @@
 arb-dir: lib/l10n
 template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
+synthetic-package: false
+output-dir: lib/l10n/generated
+

--- a/lib/app/photo_booth/photo_booth.dart
+++ b/lib/app/photo_booth/photo_booth.dart
@@ -68,6 +68,7 @@ class PhotoBoothState extends State<PhotoBooth> {
                     AppLocalizations.delegate,
                     GlobalMaterialLocalizations.delegate,
                     GlobalWidgetsLocalizations.delegate,
+                    GlobalCupertinoLocalizations.delegate,
                     FluentLocalizations.delegate,
                   ],
                   supportedLocales: const [

--- a/lib/app/photo_booth/widgets/activity_monitor.dart
+++ b/lib/app/photo_booth/widgets/activity_monitor.dart
@@ -2,10 +2,10 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:loggy/loggy.dart';
 import 'package:mobx/mobx.dart' hide Listener;
 import 'package:momento_booth/extensions/go_router_extension.dart';
 import 'package:momento_booth/managers/_all.dart';
+import 'package:momento_booth/utils/logger.dart';
 import 'package:momento_booth/views/start_screen/start_screen.dart';
 
 class ActivityMonitor extends StatefulWidget {
@@ -20,7 +20,7 @@ class ActivityMonitor extends StatefulWidget {
 
 }
 
-class _ActivityMonitorState extends State<ActivityMonitor> with UiLoggy {
+class _ActivityMonitorState extends State<ActivityMonitor> with Logger {
 
   Timer? _returnHomeTimer;
   late ReactionDisposer _resetTimerReactionDisposer;
@@ -67,7 +67,7 @@ class _ActivityMonitorState extends State<ActivityMonitor> with UiLoggy {
 
   void _goHome() {
     if (widget.router.currentLocation == StartScreen.defaultRoute) return;
-    loggy.debug("Returning to homescreen because Home screen timeout was reached.");
+    logDebug("Returning to homescreen because Home screen timeout was reached.");
     widget.router.go(StartScreen.defaultRoute);
   }
 

--- a/lib/app/photo_booth/widgets/photo_booth_hotkey_monitor.dart
+++ b/lib/app/photo_booth/widgets/photo_booth_hotkey_monitor.dart
@@ -3,12 +3,12 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
-import 'package:loggy/loggy.dart';
 import 'package:momento_booth/extensions/go_router_extension.dart';
+import 'package:momento_booth/utils/logger.dart';
 import 'package:momento_booth/views/manual_collage_screen/manual_collage_screen.dart';
 import 'package:momento_booth/views/start_screen/start_screen.dart';
 
-class PhotoBoothHotkeyMonitor extends StatelessWidget with UiLoggy {
+class PhotoBoothHotkeyMonitor extends StatelessWidget with Logger {
 
   final GoRouter router;
   final Widget child;

--- a/lib/app/shell/shell.dart
+++ b/lib/app/shell/shell.dart
@@ -2,7 +2,6 @@ import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:go_router/go_router.dart';
-import 'package:loggy/loggy.dart';
 import 'package:momento_booth/app/photo_booth/photo_booth.dart';
 import 'package:momento_booth/app/shell/widgets/fps_monitor.dart';
 import 'package:momento_booth/app/shell/widgets/shell_hotkey_monitor.dart';
@@ -26,7 +25,7 @@ class Shell extends StatefulWidget {
 
 }
 
-class _ShellState extends State<Shell> with UiLoggy, WindowListener {
+class _ShellState extends State<Shell> with WindowListener {
 
   final GoRouter _router = GoRouter(
     routes: _rootRoutes,

--- a/lib/app/shell/shell.dart
+++ b/lib/app/shell/shell.dart
@@ -61,6 +61,7 @@ class _ShellState extends State<Shell> with UiLoggy, WindowListener {
                 AppLocalizations.delegate,
                 GlobalMaterialLocalizations.delegate,
                 GlobalWidgetsLocalizations.delegate,
+                GlobalCupertinoLocalizations.delegate,
                 FluentLocalizations.delegate,
               ],
               supportedLocales: const [

--- a/lib/app/shell/widgets/shell_hotkey_monitor.dart
+++ b/lib/app/shell/widgets/shell_hotkey_monitor.dart
@@ -3,11 +3,10 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
-import 'package:loggy/loggy.dart';
 import 'package:momento_booth/extensions/go_router_extension.dart';
 import 'package:momento_booth/managers/_all.dart';
 
-class ShellHotkeyMonitor extends StatelessWidget with UiLoggy {
+class ShellHotkeyMonitor extends StatelessWidget {
 
   final GoRouter router;
   final Widget child;

--- a/lib/app_localizations.dart
+++ b/lib/app_localizations.dart
@@ -1,1 +1,1 @@
-export 'package:flutter_gen/gen_l10n/app_localizations.dart' show AppLocalizations;
+export 'package:momento_booth/l10n/generated/app_localizations.dart' show AppLocalizations;

--- a/lib/hardware_control/photo_capturing/live_view_stream_snapshot_capturer.dart
+++ b/lib/hardware_control/photo_capturing/live_view_stream_snapshot_capturer.dart
@@ -1,4 +1,3 @@
-import 'package:loggy/loggy.dart';
 import 'package:momento_booth/hardware_control/photo_capturing/photo_capture_method.dart';
 import 'package:momento_booth/managers/live_view_manager.dart';
 import 'package:momento_booth/models/photo_capture.dart';
@@ -6,7 +5,7 @@ import 'package:momento_booth/src/rust/api/images.dart';
 import 'package:momento_booth/src/rust/models/images.dart';
 import 'package:momento_booth/utils/platform_and_app.dart';
 
-class LiveViewStreamSnapshotCapturer extends PhotoCaptureMethod with UiLoggy {
+class LiveViewStreamSnapshotCapturer extends PhotoCaptureMethod {
 
   @override
   Duration get captureDelay => const Duration(milliseconds: -17);
@@ -32,7 +31,7 @@ class LiveViewStreamSnapshotCapturer extends PhotoCaptureMethod with UiLoggy {
       filename: 'liveview.jpg',
     );
   }
-  
+
   @override
   Future<void> clearPreviousEvents() async {}
 

--- a/lib/hardware_control/photo_capturing/photo_capture_method.dart
+++ b/lib/hardware_control/photo_capturing/photo_capture_method.dart
@@ -2,13 +2,13 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:intl/intl.dart';
-import 'package:loggy/loggy.dart' as loggy;
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/models/photo_capture.dart';
 import 'package:momento_booth/utils/file_utils.dart';
+import 'package:momento_booth/utils/logger.dart';
 import 'package:path/path.dart' as path;
 
-abstract class PhotoCaptureMethod {
+abstract class PhotoCaptureMethod with Logger {
 
   Duration get captureDelay;
 
@@ -27,9 +27,9 @@ abstract class PhotoCaptureMethod {
 
         String filePath = path.join(SettingsManager.instance.settings.hardware.captureStorageLocation, fileName);
         await writeBytesToFileLocked(filePath, fileData);
-        loggy.logDebug("Stored incoming photo to disk: $filePath");
+        logDebug("Stored incoming photo to disk: $filePath");
       } catch (exception, stacktrace) {
-        loggy.logError("Could not save photo to disk", exception, stacktrace);
+        logError("Could not save photo to disk", exception, stacktrace);
       }
     }
   }

--- a/lib/hardware_control/photo_capturing/sony_remote_photo_capture.dart
+++ b/lib/hardware_control/photo_capturing/sony_remote_photo_capture.dart
@@ -2,19 +2,19 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/services.dart';
-import 'package:loggy/loggy.dart';
 import 'package:momento_booth/exceptions/photo_capture_exception.dart';
 import 'package:momento_booth/hardware_control/photo_capturing/photo_capture_method.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/models/photo_capture.dart';
 import 'package:momento_booth/utils/file_utils.dart';
+import 'package:momento_booth/utils/logger.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 
 /// Capture method that captures an image by automating the Sony Imaging Edge Desktop application (Windows only).
 /// This solution exists because gPhoto2 and other possibly better solutions require driver overrides on Windows or
 /// require bundling shared libraries which we do not support at the moment.
-class SonyRemotePhotoCapture extends PhotoCaptureMethod with UiLoggy {
+class SonyRemotePhotoCapture extends PhotoCaptureMethod with Logger {
 
   static const String autoItScriptFileName = "sony_remote_capture_photo.au3";
 
@@ -29,7 +29,7 @@ class SonyRemotePhotoCapture extends PhotoCaptureMethod with UiLoggy {
   Duration get captureDelay => Duration(milliseconds: SettingsManager.instance.settings.hardware.captureDelaySony);
 
   Future<void> _capture() async {
-    loggy.debug("Sending capture command to Sony Remote");
+    logDebug("Sending capture command to Sony Remote");
     // AutoIt script line
     // https://ss64.com/nt/syntax-esc.html
     var autoItScriptPath = await _ensureAutoItScriptIsExtracted();
@@ -42,7 +42,7 @@ class SonyRemotePhotoCapture extends PhotoCaptureMethod with UiLoggy {
     try {
       final file = await waitForFile(directoryPath, ".jpg");
       final img = await file.readAsBytes();
-      loggy.debug('Photo found: ${file.path}');
+      logDebug('Photo found: ${file.path}');
       return PhotoCapture(
         data: img,
         filename: path.basename(file.path),
@@ -59,7 +59,7 @@ class SonyRemotePhotoCapture extends PhotoCaptureMethod with UiLoggy {
   }
 
   Future<File> waitForFile(String directoryPath, String fileExtension) async {
-    loggy.debug("Checking for new $fileExtension files");
+    logDebug("Checking for new $fileExtension files");
 
     final stopTime = DateTime.now().add(const Duration(seconds: 5));
     final dir = Directory(directoryPath);
@@ -83,7 +83,7 @@ class SonyRemotePhotoCapture extends PhotoCaptureMethod with UiLoggy {
     if (!File(localPath).existsSync()) {
       final imageBytes = await rootBundle.load('assets/scripts/$autoItScriptFileName');
       await writeBytesToFileLocked(localPath, imageBytes.buffer.asUint8List());
-      loggy.info("Written Sony Remote AutoIt capture script to: $localPath");
+      logInfo("Written Sony Remote AutoIt capture script to: $localPath");
     }
     return localPath;
   }

--- a/lib/hardware_control/printing/cups_client.dart
+++ b/lib/hardware_control/printing/cups_client.dart
@@ -30,7 +30,7 @@ class CupsClient extends PrintingSystemClient {
 
       // Ignore printers that are not available.
       if (selected == null) {
-        loggy.error("Could not find selected CUPS printer [$id]");
+        logError("Could not find selected CUPS printer [$id]");
       } else {
         printers.add(selected);
       }

--- a/lib/hardware_control/printing/flutter_printing_client.dart
+++ b/lib/hardware_control/printing/flutter_printing_client.dart
@@ -1,7 +1,6 @@
 import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
-import 'package:loggy/loggy.dart';
 import 'package:momento_booth/exceptions/printing_exception.dart';
 import 'package:momento_booth/hardware_control/printing/printing_system_client.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
@@ -10,7 +9,7 @@ import 'package:printing/printing.dart';
 
 /// Printing implementation that uses the flutter `printing` library to print.
 /// This should work on all operating systems.
-class FlutterPrintingClient extends PrintingSystemClient with UiLoggy {
+class FlutterPrintingClient extends PrintingSystemClient {
 
   @override
   Future<List<PrintQueueInfo>> getPrintQueues() async {
@@ -28,7 +27,7 @@ class FlutterPrintingClient extends PrintingSystemClient with UiLoggy {
 
       // Ignore printers that are not available.
       if (selected == null) {
-        loggy.error("Could not find selected printer ($name)");
+        logError("Could not find selected printer ($name)");
       } else {
         printers.add(selected);
       }
@@ -42,7 +41,7 @@ class FlutterPrintingClient extends PrintingSystemClient with UiLoggy {
     List<Printer> selectedPrintQueues = await _getSelectedPrintQueues();
     return selectedPrintQueues.map((queue) => queue.asPrintQueueInfo).toList();
   }
-  
+
   @override
   Future<void> printPdfToQueue(String queueId, String taskName, Uint8List pdfData) async {
     // Find specific printer
@@ -61,7 +60,7 @@ class FlutterPrintingClient extends PrintingSystemClient with UiLoggy {
 
     if (!success) throw PrintingException('Printing.directPrintPdf returned false');
   }
-  
+
 }
 
 extension _PrinterExtension on Printer {

--- a/lib/hardware_control/printing/printing_system_client.dart
+++ b/lib/hardware_control/printing/printing_system_client.dart
@@ -1,16 +1,16 @@
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:loggy/loggy.dart';
 import 'package:momento_booth/exceptions/printing_exception.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
 import 'package:momento_booth/models/print_queue_info.dart';
 import 'package:momento_booth/utils/file_utils.dart';
+import 'package:momento_booth/utils/logger.dart';
 import 'package:path/path.dart' as path;
 
 /// Abstract class for printing systems. This assumes every printing system allows setting multiple printers. As such it wil automatically cycle through the printers when picking a printer for a new job.
-abstract class PrintingSystemClient with UiLoggy {
+abstract class PrintingSystemClient with Logger {
 
   int lastUsedPrinterIndex = -1;
 
@@ -27,7 +27,7 @@ abstract class PrintingSystemClient with UiLoggy {
     if (++lastUsedPrinterIndex >= printers.length) lastUsedPrinterIndex = 0;
     final PrintQueueInfo printer = printers[lastUsedPrinterIndex];
 
-    loggy.debug("Printing with printer #${lastUsedPrinterIndex + 1} [${printer.name}]");
+    logDebug("Printing with printer #${lastUsedPrinterIndex + 1} [${printer.name}]");
 
     await printPdfToQueue(printer.id, taskName, pdfData);
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,7 @@
 import 'dart:io';
 
 import 'package:fluent_ui/fluent_ui.dart';
-import 'package:flutter_loggy/flutter_loggy.dart';
 import 'package:get_it/get_it.dart';
-import 'package:loggy/loggy.dart';
 import 'package:momento_booth/app/shell/shell.dart';
 import 'package:momento_booth/managers/_all.dart';
 import 'package:momento_booth/managers/printing_manager.dart';
@@ -14,6 +12,7 @@ import 'package:momento_booth/utils/environment_variables.dart';
 import 'package:momento_booth/utils/platform_and_app.dart';
 import 'package:path/path.dart' as path;
 import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:talker_flutter/talker_flutter.dart';
 
 final GetIt getIt = GetIt.instance;
 
@@ -24,9 +23,11 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await initialize();
 
-  getIt.registerSingleton<SecretRepository>(const SecureStorageSecretRepository());
-
-  Loggy.initLoggy(logPrinter: StreamPrinter(const PrettyDeveloperPrinter()));
+  getIt
+    ..registerSingleton(Talker(
+      settings: TalkerSettings(),
+    ))
+    ..registerSingleton<SecretRepository>(const SecureStorageSecretRepository());
 
   await HelperLibraryInitializationManager.instance.initialize();
   await SettingsManager.instance.load();
@@ -68,7 +69,7 @@ void _ensureGPhoto2EnvironmentVariables() {
 Future<String?> _resolveSentryDsnOverride() async {
   String executablePath = Platform.resolvedExecutable;
   String possibleSentryDsnOverridePath = path.join(path.dirname(executablePath), "sentry_dsn_override.txt");
-  
+
   File sentryDsnOverrideFile = File(possibleSentryDsnOverridePath);
   if (!sentryDsnOverrideFile.existsSync()) return null;
   return (await sentryDsnOverrideFile.readAsString()).trim();

--- a/lib/managers/helper_library_initialization_manager.dart
+++ b/lib/managers/helper_library_initialization_manager.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 
-import 'package:loggy/loggy.dart' as loggy;
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/src/rust/api/initialization.dart';
 import 'package:momento_booth/src/rust/helpers.dart';
+import 'package:momento_booth/utils/logger.dart';
 
 part 'helper_library_initialization_manager.g.dart';
 
@@ -16,7 +16,7 @@ class HelperLibraryInitializationManager extends _HelperLibraryInitializationMan
 }
 
 /// Class containing global state for photos in the app
-abstract class _HelperLibraryInitializationManagerBase with Store {
+abstract class _HelperLibraryInitializationManagerBase with Store, Logger {
 
   final Completer<bool> _nokhwaInitializationResultCompleter = Completer<bool>();
   final Completer<bool> _gphoto2InitializationResultCompleter = Completer<bool>();
@@ -38,13 +38,13 @@ abstract class _HelperLibraryInitializationManagerBase with Store {
   void _processLogEvent(LogEvent event) {
     switch (event.level) {
       case LogLevel.debug:
-        loggy.logDebug("Lib: ${event.message}");
+        logDebug("Lib: ${event.message}");
       case LogLevel.info:
-        loggy.logInfo("Lib: ${event.message}");
+        logInfo("Lib: ${event.message}");
       case LogLevel.warning:
-        loggy.logWarning("Lib: ${event.message}");
+        logWarning("Lib: ${event.message}");
       case LogLevel.error:
-        loggy.logError("Lib: ${event.message}");
+        logError("Lib: ${event.message}");
     }
   }
 
@@ -53,11 +53,11 @@ abstract class _HelperLibraryInitializationManagerBase with Store {
       case HardwareInitializationStep.nokhwa:
         _nokhwaInitializationMessage = event.message;
         _nokhwaInitializationResultCompleter.complete(event.hasSucceeded);
-        loggy.logInfo("Nokhwa initialization finished with result: ${event.hasSucceeded} and message: ${event.message}");
+        logInfo("Nokhwa initialization finished with result: ${event.hasSucceeded} and message: ${event.message}");
       case HardwareInitializationStep.gphoto2:
         _gphoto2InitializationMessage = event.message;
         _gphoto2InitializationResultCompleter.complete(event.hasSucceeded);
-        loggy.logInfo("gPhoto2 initialization finished with result: ${event.hasSucceeded} and message: ${event.message}");
+        logInfo("gPhoto2 initialization finished with result: ${event.hasSucceeded} and message: ${event.message}");
     }
   }
 

--- a/lib/managers/live_view_manager.dart
+++ b/lib/managers/live_view_manager.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:collection/collection.dart';
-import 'package:loggy/loggy.dart';
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/extensions/camera_state_extension.dart';
 import 'package:momento_booth/hardware_control/gphoto2_camera.dart';
@@ -26,7 +25,7 @@ class LiveViewManager extends _LiveViewManagerBase with _$LiveViewManager {
 }
 
 /// Class containing global state for photos in the app
-abstract class _LiveViewManagerBase with Store, UiLoggy {
+abstract class _LiveViewManagerBase with Store {
 
   @readonly
   bool _lastFrameWasInvalid = false;

--- a/lib/managers/printing_manager.dart
+++ b/lib/managers/printing_manager.dart
@@ -1,7 +1,6 @@
 
 import 'dart:typed_data';
 
-import 'package:loggy/loggy.dart';
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/hardware_control/printing/cups_client.dart';
 import 'package:momento_booth/hardware_control/printing/flutter_printing_client.dart';
@@ -19,7 +18,7 @@ class PrintingManager extends _PrintingManagerBase with _$PrintingManager {
 
 }
 
-abstract class _PrintingManagerBase with Store, UiLoggy {
+abstract class _PrintingManagerBase with Store {
 
   // ////////////// //
   // Initialization //
@@ -33,7 +32,7 @@ abstract class _PrintingManagerBase with Store, UiLoggy {
     });
   }
 
-  
+
   // ///////// //
   // Reactions //
   // ///////// //

--- a/lib/managers/settings_manager.dart
+++ b/lib/managers/settings_manager.dart
@@ -1,9 +1,9 @@
 import 'dart:io';
 
-import 'package:loggy/loggy.dart';
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/managers/mqtt_manager.dart';
 import 'package:momento_booth/models/settings.dart';
+import 'package:momento_booth/utils/logger.dart';
 import 'package:path/path.dart' hide context;
 import 'package:path_provider/path_provider.dart';
 import 'package:toml/toml.dart';
@@ -18,7 +18,7 @@ class SettingsManager extends _SettingsManagerBase with _$SettingsManager {
 
 }
 
-abstract class _SettingsManagerBase with Store, UiLoggy {
+abstract class _SettingsManagerBase with Store, Logger {
 
   static const _fileName = "MomentoBooth_Settings.toml";
 
@@ -41,14 +41,14 @@ abstract class _SettingsManagerBase with Store, UiLoggy {
     MqttManager.instance.publishSettings(settings);
     await _save();
   }
-  
+
   // /////////// //
   // Persistence //
   // /////////// //
 
   @action
   Future<void> load() async {
-    loggy.debug("Loading settings");
+    logDebug("Loading settings");
     await _ensureSettingsFileIsSet();
 
     if (!_settingsFile.existsSync()) {
@@ -64,7 +64,7 @@ abstract class _SettingsManagerBase with Store, UiLoggy {
     Map<String, dynamic> settingsMap = settingsDocument.toMap();
     try {
       _settings = Settings.fromJson(settingsMap);
-      loggy.debug("Loaded settings: ${_settings?.toJson().toString() ?? "null"}");
+      logDebug("Loaded settings: ${_settings?.toJson().toString() ?? "null"}");
     } catch (_) {
       // Fixme: Failed to parse, load defaults and create settings file
       _settings = Settings.withDefaults();
@@ -73,7 +73,7 @@ abstract class _SettingsManagerBase with Store, UiLoggy {
   }
 
   Future<void> _save() async {
-    loggy.debug("Saving settings");
+    logDebug("Saving settings");
     await _ensureSettingsFileIsSet();
 
     Map<String, dynamic> settingsMap = _settings!.toJson();
@@ -81,7 +81,7 @@ abstract class _SettingsManagerBase with Store, UiLoggy {
     String settingsAsToml = settingsDocument.toString();
     await _settingsFile.writeAsString(settingsAsToml);
 
-    loggy.debug("Saved settings");
+    logDebug("Saved settings");
   }
 
   // /////// //

--- a/lib/managers/sfx_manager.dart
+++ b/lib/managers/sfx_manager.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 
 import 'package:just_audio/just_audio.dart';
-import 'package:loggy/loggy.dart';
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
+import 'package:momento_booth/utils/logger.dart';
 
 part 'sfx_manager.g.dart';
 
@@ -13,7 +13,7 @@ class SfxManager extends _SfxManagerBase with _$SfxManager {
   SfxManager._internal();
 }
 
-abstract class _SfxManagerBase with Store, UiLoggy {
+abstract class _SfxManagerBase with Store, Logger {
 
   AudioPlayer? _audioPlayer;
 
@@ -30,7 +30,7 @@ abstract class _SfxManagerBase with Store, UiLoggy {
 
       _audioPlayer = audioPlayer;
     } catch (e) {
-      loggy.error("Error initializing audio player: $e");
+      logError("Error initializing audio player: $e");
     }
   }
 
@@ -61,7 +61,7 @@ abstract class _SfxManagerBase with Store, UiLoggy {
       await _audioPlayer?.setFilePath(filePath);
       await _audioPlayer?.play();
     } catch (e) {
-      loggy.error("Error playing sound ($filePath): $e");
+      logError("Error playing sound ($filePath): $e");
     }
   }
 

--- a/lib/managers/stats_manager.dart
+++ b/lib/managers/stats_manager.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:loggy/loggy.dart';
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/models/stats.dart';
+import 'package:momento_booth/utils/logger.dart';
 import 'package:path/path.dart' hide context;
 import 'package:path_provider/path_provider.dart';
 import 'package:synchronized/synchronized.dart';
@@ -30,7 +30,7 @@ enum StatFields {
   createdMultiCapturePhotos,
 }
 
-abstract class _StatsManagerBase with Store, UiLoggy {
+abstract class _StatsManagerBase with Store, Logger {
 
   @readonly
   Stats _stats = const Stats();
@@ -84,25 +84,25 @@ abstract class _StatsManagerBase with Store, UiLoggy {
 
   @action
   Future<void> load() async {
-    loggy.debug("Loading statistics");
+    logDebug("Loading statistics");
     await _ensureStatsFileIsSet();
 
     if (!_statsFile.existsSync()) {
       // File does not exist
       _stats = const Stats();
-      loggy.warning("Persisted statistics file not found"); 
+      logWarning("Persisted statistics file not found");
     } else {
       // File does exist
-      loggy.debug("Loading persisted statistics");
+      logDebug("Loading persisted statistics");
       try {
         String statsAsToml = await _statsFile.readAsString();
         TomlDocument statsDocument = TomlDocument.parse(statsAsToml);
         Map<String, dynamic> statsMap = statsDocument.toMap();
         _stats = Stats.fromJson(statsMap);
-        loggy.debug("Loaded persisted statistics");
+        logDebug("Loaded persisted statistics");
       } catch (_) {
         // Fixme: Failed to parse, ignore for now
-        loggy.warning("Persisted statistics could not be loaded"); 
+        logWarning("Persisted statistics could not be loaded");
       }
     }
 
@@ -111,7 +111,7 @@ abstract class _StatsManagerBase with Store, UiLoggy {
 
   Future<void> _save() async {
     await _stateSaveLock.synchronized(() async {
-      loggy.debug("Saving statistics");
+      logDebug("Saving statistics");
       await _ensureStatsFileIsSet();
 
       Map<String, dynamic> mapWithStringKey = _stats.toJson();
@@ -119,7 +119,7 @@ abstract class _StatsManagerBase with Store, UiLoggy {
       String statsAsToml = statsDocument.toString();
       await _statsFile.writeAsString(statsAsToml);
 
-      loggy.debug("Saved statistics");
+      logDebug("Saved statistics");
     });
   }
 

--- a/lib/managers/window_manager.dart
+++ b/lib/managers/window_manager.dart
@@ -1,5 +1,5 @@
-import 'package:loggy/loggy.dart';
 import 'package:mobx/mobx.dart';
+import 'package:momento_booth/utils/logger.dart';
 import 'package:window_manager/window_manager.dart';
 
 part 'window_manager.g.dart';
@@ -12,8 +12,8 @@ class WindowManager extends _WindowManagerBase with _$WindowManager {
 
 }
 
-abstract class _WindowManagerBase with Store, UiLoggy {
-  
+abstract class _WindowManagerBase with Store, Logger {
+
   bool _isFullScreen = false;
 
   // ////////////// //
@@ -32,7 +32,7 @@ abstract class _WindowManagerBase with Store, UiLoggy {
   @action
   void toggleFullscreen() {
     _isFullScreen = !_isFullScreen;
-    loggy.debug("Setting fullscreen to $_isFullScreen");
+    logDebug("Setting fullscreen to $_isFullScreen");
     windowManager.setFullScreen(_isFullScreen);
   }
 

--- a/lib/utils/logger.dart
+++ b/lib/utils/logger.dart
@@ -1,0 +1,24 @@
+import 'package:momento_booth/main.dart';
+import 'package:talker/talker.dart';
+
+mixin Logger {
+
+  static final Talker _talker = getIt<Talker>();
+
+  void logError(dynamic msg, [Object? exception, StackTrace? stackTrace]) {
+    _talker.error("[$runtimeType] $msg", exception, stackTrace);
+  }
+
+  void logWarning(dynamic msg, [Object? exception, StackTrace? stackTrace]) {
+    _talker.warning("[$runtimeType] $msg", exception, stackTrace);
+  }
+
+  void logInfo(dynamic msg, [Object? exception, StackTrace? stackTrace]) {
+    _talker.info("[$runtimeType] $msg", exception, stackTrace);
+  }
+
+  void logDebug(dynamic msg, [Object? exception, StackTrace? stackTrace]) {
+    _talker.debug("[$runtimeType] $msg", exception, stackTrace);
+  }
+
+}

--- a/lib/utils/route_observer.dart
+++ b/lib/utils/route_observer.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
-import 'package:loggy/loggy.dart';
 import 'package:momento_booth/managers/mqtt_manager.dart';
+import 'package:momento_booth/utils/logger.dart';
 
-class GoRouterObserver extends NavigatorObserver with UiLoggy {
+class GoRouterObserver extends NavigatorObserver with Logger {
 
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
@@ -11,10 +11,10 @@ class GoRouterObserver extends NavigatorObserver with UiLoggy {
       CustomTransitionPage page = route.settings as CustomTransitionPage;
       String routeType = page.child.runtimeType.toString();
 
-      loggy.debug("Route push: $routeType");
+      logDebug("Route push: $routeType");
       MqttManager.instance.publishScreen(routeType);
     } else {
-      loggy.debug("Route push: Unknown (is not a CustomTransitionPage))");
+      logDebug("Route push: Unknown (is not a CustomTransitionPage))");
     }
   }
 
@@ -24,10 +24,10 @@ class GoRouterObserver extends NavigatorObserver with UiLoggy {
       CustomTransitionPage page = route.settings as CustomTransitionPage;
       String routeType = page.child.runtimeType.toString();
 
-      loggy.debug("Route pop: $routeType");
+      logDebug("Route pop: $routeType");
       MqttManager.instance.publishScreen(routeType);
     } else {
-      loggy.debug("Route pop: Unknown (is not a CustomTransitionPage))");
+      logDebug("Route pop: Unknown (is not a CustomTransitionPage))");
     }
   }
 
@@ -37,9 +37,9 @@ class GoRouterObserver extends NavigatorObserver with UiLoggy {
       CustomTransitionPage page = route.settings as CustomTransitionPage;
       String routeType = page.child.runtimeType.toString();
 
-      loggy.debug("Route remove: $routeType");
+      logDebug("Route remove: $routeType");
     } else {
-      loggy.debug("Route remove: Unknown (is not a CustomTransitionPage))");
+      logDebug("Route remove: Unknown (is not a CustomTransitionPage))");
     }
   }
 
@@ -61,7 +61,7 @@ class GoRouterObserver extends NavigatorObserver with UiLoggy {
       oldRouteChildName = page.child.runtimeType.toString();
     }
 
-    loggy.debug("Route replaced ${oldRouteChildName ?? 'Unknown (is not a CustomTransitionPage)'} with ${newRouteChildName ?? 'Unknown (is not a CustomTransitionPage)'}");
+    logDebug("Route replaced ${oldRouteChildName ?? 'Unknown (is not a CustomTransitionPage)'} with ${newRouteChildName ?? 'Unknown (is not a CustomTransitionPage)'}");
     if (newRouteChildName != null) MqttManager.instance.publishScreen(newRouteChildName);
   }
 

--- a/lib/views/base/printer_status_dialog_mixin.dart
+++ b/lib/views/base/printer_status_dialog_mixin.dart
@@ -1,6 +1,5 @@
 // ignore_for_file: dead_code
 
-import 'package:loggy/loggy.dart';
 import 'package:momento_booth/hardware_control/printing/cups_client.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/models/printer_issue_type.dart';
@@ -10,7 +9,7 @@ import 'package:momento_booth/views/base/screen_controller_base.dart';
 import 'package:momento_booth/views/base/screen_view_model_base.dart';
 import 'package:momento_booth/views/custom_widgets/dialogs/printer_issue_dialog.dart';
 
-mixin PrinterStatusDialogMixin<T extends ScreenViewModelBase> on ScreenControllerBase<T>, UiLoggy {
+mixin PrinterStatusDialogMixin<T extends ScreenViewModelBase> on ScreenControllerBase<T> {
 
   Future<void> checkPrintersAndShowWarnings() async {
     return; // TODO: Remove this line when the feature is ready.
@@ -27,7 +26,7 @@ mixin PrinterStatusDialogMixin<T extends ScreenViewModelBase> on ScreenControlle
           await _showDialog(printerState, printerId, stuckJobs);
         }
       } catch (e) {
-        loggy.debug("Failed to query printer [$printerId] with error: $e");
+        logDebug("Failed to query printer [$printerId] with error: $e");
       }
     }
   }
@@ -47,14 +46,14 @@ mixin PrinterStatusDialogMixin<T extends ScreenViewModelBase> on ScreenControlle
           try {
             await cupsResumePrinter(serverInfo: CupsClient.serverInfo, queueId: printerId);
           } catch (e) {
-            loggy.debug("Failed to resume printer [$printerId] with error: $e");
+            logDebug("Failed to resume printer [$printerId] with error: $e");
           }
 
           for (PrintJobState job in stuckJobs) {
             try {
               await cupsReleaseJob(serverInfo: CupsClient.serverInfo, queueId: printerId, jobId: job.id);
             } catch (e) {
-              loggy.debug("Failed to release stuck job [${job.name}] for printer [$printerId] with error: $e");
+              logDebug("Failed to release stuck job [${job.name}] for printer [$printerId] with error: $e");
             }
           }
         },

--- a/lib/views/base/screen_controller_base.dart
+++ b/lib/views/base/screen_controller_base.dart
@@ -1,9 +1,10 @@
 import 'package:meta/meta.dart';
+import 'package:momento_booth/utils/logger.dart';
 import 'package:momento_booth/views/base/build_context_abstractor.dart';
 import 'package:momento_booth/views/base/build_context_accessor.dart';
 import 'package:momento_booth/views/base/screen_view_model_base.dart';
 
-abstract class ScreenControllerBase<T extends ScreenViewModelBase> with BuildContextAbstractor {
+abstract class ScreenControllerBase<T extends ScreenViewModelBase> with BuildContextAbstractor, Logger {
 
   final T viewModel;
 

--- a/lib/views/base/screen_view_model_base.dart
+++ b/lib/views/base/screen_view_model_base.dart
@@ -1,8 +1,9 @@
 import 'package:meta/meta.dart';
+import 'package:momento_booth/utils/logger.dart';
 import 'package:momento_booth/views/base/build_context_abstractor.dart';
 import 'package:momento_booth/views/base/build_context_accessor.dart';
 
-abstract class ScreenViewModelBase with BuildContextAbstractor {
+abstract class ScreenViewModelBase with BuildContextAbstractor, Logger {
 
   @override
   final BuildContextAccessor contextAccessor;
@@ -13,5 +14,5 @@ abstract class ScreenViewModelBase with BuildContextAbstractor {
 
   @mustCallSuper
   void dispose() {}
-  
+
 }

--- a/lib/views/capture_screen/capture_screen_view_model.dart
+++ b/lib/views/capture_screen/capture_screen_view_model.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:loggy/loggy.dart';
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/hardware_control/gphoto2_camera.dart';
 import 'package:momento_booth/hardware_control/photo_capturing/live_view_stream_snapshot_capturer.dart';
@@ -25,7 +24,7 @@ part 'capture_screen_view_model.g.dart';
 
 class CaptureScreenViewModel = CaptureScreenViewModelBase with _$CaptureScreenViewModel;
 
-abstract class CaptureScreenViewModelBase extends ScreenViewModelBase with Store, UiLoggy {
+abstract class CaptureScreenViewModelBase extends ScreenViewModelBase with Store {
 
   late final PhotoCaptureMethod capturer;
   bool flashComplete = false;
@@ -87,7 +86,7 @@ abstract class CaptureScreenViewModelBase extends ScreenViewModelBase with Store
       format: format,
       jpgQuality: jpgQuality,
     );
-    loggy.debug('captureCollage took ${stopwatch.elapsed}');
+    logDebug('captureCollage took ${stopwatch.elapsed}');
 
     return await PhotosManager.instance.writeOutput();
   }
@@ -99,7 +98,7 @@ abstract class CaptureScreenViewModelBase extends ScreenViewModelBase with Store
       CaptureMethod.sonyImagingEdgeDesktop => SonyRemotePhotoCapture(SettingsManager.instance.settings.hardware.captureLocation),
       CaptureMethod.liveViewSource => LiveViewStreamSnapshotCapturer(),
       CaptureMethod.gPhoto2 => LiveViewManager.instance.gPhoto2Camera!,
-    } as PhotoCaptureMethod;
+    };
     capturer.clearPreviousEvents();
 
     if (autoFocusMsBeforeCapture > 0 && autoFocusDelay > Duration.zero && capturer is GPhoto2Camera) {
@@ -136,7 +135,7 @@ abstract class CaptureScreenViewModelBase extends ScreenViewModelBase with Store
         await PhotosManager.instance.writeOutput();
       }
     } catch (error) {
-      loggy.warning(error);
+      logWarning(error);
       final ByteData data = await rootBundle.load('assets/bitmap/capture-error.png');
       PhotosManager.instance.outputImage = data.buffer.asUint8List();
     } finally {

--- a/lib/views/collage_maker_screen/collage_maker_screen_controller.dart
+++ b/lib/views/collage_maker_screen/collage_maker_screen_controller.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/widgets.dart';
-import 'package:loggy/loggy.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
@@ -9,7 +8,7 @@ import 'package:momento_booth/views/collage_maker_screen/collage_maker_screen_vi
 import 'package:momento_booth/views/custom_widgets/photo_collage.dart';
 import 'package:momento_booth/views/share_screen/share_screen.dart';
 
-class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScreenViewModel> with UiLoggy {
+class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScreenViewModel> {
 
   // Initialization/Deinitialization
 
@@ -54,11 +53,11 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
       format: format,
       jpgQuality: jpgQuality,
     );
-    loggy.debug('captureCollage took ${stopwatch.elapsed}');
+    logDebug('captureCollage took ${stopwatch.elapsed}');
 
     if (latestCapture == thisCapture) {
       PhotosManager.instance.outputImage = exportImage;
-      loggy.debug("Written collage image to output image memory");
+      logDebug("Written collage image to output image memory");
       await PhotosManager.instance.writeOutput();
       viewModel.readyToContinue = true;
     }

--- a/lib/views/custom_widgets/dialogs/find_face_dialog.dart
+++ b/lib/views/custom_widgets/dialogs/find_face_dialog.dart
@@ -6,7 +6,6 @@ import 'package:flutter/widgets.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:http/http.dart' as http;
 import 'package:http_parser/http_parser.dart';
-import 'package:loggy/loggy.dart';
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/app_localizations.dart';
 import 'package:momento_booth/hardware_control/photo_capturing/live_view_stream_snapshot_capturer.dart';
@@ -15,6 +14,7 @@ import 'package:momento_booth/hardware_control/photo_capturing/sony_remote_photo
 import 'package:momento_booth/managers/live_view_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/models/settings.dart';
+import 'package:momento_booth/utils/logger.dart';
 import 'package:momento_booth/views/custom_widgets/buttons/photo_booth_filled_button.dart';
 import 'package:momento_booth/views/custom_widgets/buttons/photo_booth_outlined_button.dart';
 import 'package:momento_booth/views/custom_widgets/capture_counter.dart';
@@ -43,7 +43,7 @@ class FindFaceDialog extends StatefulWidget {
 
 }
 
-class _FindFaceDialogState extends State<FindFaceDialog> with UiLoggy {
+class _FindFaceDialogState extends State<FindFaceDialog> with Logger {
 
   bool _showCounter = true;
   FaceDetectionState _faceDetectionState = FaceDetectionState.unknown;
@@ -54,8 +54,8 @@ class _FindFaceDialogState extends State<FindFaceDialog> with UiLoggy {
     CaptureMethod.sonyImagingEdgeDesktop => SonyRemotePhotoCapture(SettingsManager.instance.settings.hardware.captureLocation),
     CaptureMethod.liveViewSource => LiveViewStreamSnapshotCapturer(),
     CaptureMethod.gPhoto2 => LiveViewManager.instance.gPhoto2Camera!,
-  } as PhotoCaptureMethod;
-  
+  };
+
   @computed
   Duration get photoDelay => Duration(seconds: widget.countDown) - capturer.captureDelay + flashStartDuration;
 
@@ -65,7 +65,7 @@ class _FindFaceDialogState extends State<FindFaceDialog> with UiLoggy {
       final image = await capturer.captureAndGetPhoto();
       imageData = image.data;
     } catch (error) {
-      loggy.warning(error);
+      logWarning(error);
       final ByteData data = await rootBundle.load('assets/bitmap/capture-error.png');
       imageData = data.buffer.asUint8List();
     }
@@ -73,7 +73,7 @@ class _FindFaceDialogState extends State<FindFaceDialog> with UiLoggy {
   }
 
   Future<void> uploadImage(Uint8List image) async {
-    loggy.debug("Uploading image to face detection server");
+    logDebug("Uploading image to face detection server");
     Uri uri = Uri(host: "localhost", port: 3232, scheme: "http", path: "/upload");
     var request = http.MultipartRequest("POST", uri);
     request.files.add(http.MultipartFile.fromBytes("file", image, contentType: MediaType('image', 'jpeg'), filename: "captured-imaged.jpg"));
@@ -89,7 +89,7 @@ class _FindFaceDialogState extends State<FindFaceDialog> with UiLoggy {
         _numFaces = data['num'];
       }
     });
-    loggy.debug("Face detection state updated: $_faceDetectionState, $_numFaces");
+    logDebug("Face detection state updated: $_faceDetectionState, $_numFaces");
     widget.onSuccess();
   }
 
@@ -101,7 +101,7 @@ class _FindFaceDialogState extends State<FindFaceDialog> with UiLoggy {
 
   void capture() {
     setState(() => _showCounter = false);
-    loggy.debug("Capture initiated with method $capturer");
+    logDebug("Capture initiated with method $capturer");
   }
 
   @override

--- a/lib/views/custom_widgets/photo_collage.dart
+++ b/lib/views/custom_widgets/photo_collage.dart
@@ -10,7 +10,6 @@ import 'package:flutter/material.dart' hide Action, RawImage;
 import 'package:flutter_layout_grid/flutter_layout_grid.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:loggy/loggy.dart';
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/app_localizations.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
@@ -23,6 +22,7 @@ import 'package:momento_booth/src/rust/api/images.dart';
 import 'package:momento_booth/src/rust/models/images.dart';
 import 'package:momento_booth/src/rust/utils/image_processing.dart';
 import 'package:momento_booth/theme/momento_booth_theme_data.dart';
+import 'package:momento_booth/utils/logger.dart';
 import 'package:momento_booth/utils/platform_and_app.dart';
 import 'package:momento_booth/views/custom_widgets/image_with_loader_fallback.dart';
 import 'package:momento_booth/views/custom_widgets/photo_container.dart';
@@ -73,7 +73,7 @@ class PhotoCollage extends StatefulWidget {
 
 }
 
-class PhotoCollageState extends State<PhotoCollage> with UiLoggy {
+class PhotoCollageState extends State<PhotoCollage> with Logger {
 
   @override
   void initState() {
@@ -385,7 +385,7 @@ class PhotoCollageState extends State<PhotoCollage> with UiLoggy {
       ],
       operationsBeforeEncoding: operationsBeforeEncoding,
     );
-    loggy.debug('JPEG encoding took ${stopwatch.elapsed}');
+    logDebug('JPEG encoding took ${stopwatch.elapsed}');
 
     return jpegData;
   }

--- a/lib/views/gallery_screen/gallery_screen_controller.dart
+++ b/lib/views/gallery_screen/gallery_screen_controller.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:http/http.dart' as http;
-import 'package:loggy/loggy.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
 import 'package:momento_booth/views/custom_widgets/dialogs/find_face_dialog.dart';
@@ -12,7 +11,7 @@ import 'package:momento_booth/views/photo_details_screen/photo_details_screen.da
 import 'package:path/path.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
-class GalleryScreenController extends ScreenControllerBase<GalleryScreenViewModel> with UiLoggy {
+class GalleryScreenController extends ScreenControllerBase<GalleryScreenViewModel> {
 
   // Initialization/Deinitialization
 
@@ -23,7 +22,7 @@ class GalleryScreenController extends ScreenControllerBase<GalleryScreenViewMode
 
   void openPhoto(File file) {
     final String filename = basename(file.path);
-    loggy.debug("Opening photo $filename");
+    logDebug("Opening photo $filename");
     router.push("${PhotoDetailsScreen.defaultRoute}/$filename");
   }
 
@@ -38,13 +37,13 @@ class GalleryScreenController extends ScreenControllerBase<GalleryScreenViewMode
       if (response.statusCode == 200) {
         var matchingImages = jsonDecode(response.body) as List<dynamic>?;
         var matchingImagesStrings = matchingImages!.cast<String>().toList();
-        loggy.debug("Matching images: $matchingImagesStrings");
+        logDebug("Matching images: $matchingImagesStrings");
         viewModel.filterImages(matchingImagesStrings);
       } else {
         throw Exception("Failed to get matching images, status code: ${response.statusCode}");
       }
     } catch (e, s) {
-      loggy.error("Failed to get matching images: $e");
+      logError("Failed to get matching images: $e");
       await Sentry.captureException(e, stackTrace: s);
     }
   }

--- a/lib/views/gallery_screen/gallery_screen_view.dart
+++ b/lib/views/gallery_screen/gallery_screen_view.dart
@@ -163,9 +163,9 @@ class GalleryScreenView extends ScreenViewBase<GalleryScreenViewModel, GallerySc
           OutlinedButton.icon(
             onPressed: controller.onFindMyFace,
             style: ButtonStyle(
-              backgroundColor: MaterialStateProperty.all(Colors.blue.shade700),
-              foregroundColor: MaterialStateProperty.all(Colors.white),
-              overlayColor: MaterialStateProperty.all(Colors.blue.shade400),
+              backgroundColor: WidgetStateProperty.all(Colors.blue.shade700),
+              foregroundColor: WidgetStateProperty.all(Colors.white),
+              overlayColor: WidgetStateProperty.all(Colors.blue.shade400),
             ),
             icon: const Icon(Icons.face),
             label: const Text("Find my face"),
@@ -174,9 +174,9 @@ class GalleryScreenView extends ScreenViewBase<GalleryScreenViewModel, GallerySc
           OutlinedButton.icon(
             onPressed: controller.clearImageFilter,
             style: ButtonStyle(
-              foregroundColor: MaterialStateProperty.all(Colors.white),
-              overlayColor: MaterialStateProperty.all(Colors.red.shade900),
-              side: MaterialStateProperty.all(const BorderSide(color: Color.fromARGB(255, 255, 117, 117))),
+              foregroundColor: WidgetStateProperty.all(Colors.white),
+              overlayColor: WidgetStateProperty.all(Colors.red.shade900),
+              side: WidgetStateProperty.all(const BorderSide(color: Color.fromARGB(255, 255, 117, 117))),
             ),
             icon: const Icon(Icons.filter_alt_off),
             label: const Text("Clear filter"),
@@ -195,7 +195,7 @@ class FilterChoice extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    ButtonStyle style = ButtonStyle(foregroundColor: MaterialStateProperty.all(Colors.white));
+    ButtonStyle style = ButtonStyle(foregroundColor: WidgetStateProperty.all(Colors.white));
     return SegmentedButton<SortBy>(
       style: style,
       segments: const <ButtonSegment<SortBy>>[

--- a/lib/views/manual_collage_screen/manual_collage_screen_controller.dart
+++ b/lib/views/manual_collage_screen/manual_collage_screen_controller.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/widgets.dart';
-import 'package:loggy/loggy.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/managers/printing_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
@@ -14,7 +13,7 @@ import 'package:momento_booth/views/custom_widgets/photo_collage.dart';
 import 'package:momento_booth/views/manual_collage_screen/manual_collage_screen_view_model.dart';
 import 'package:path/path.dart' as path;
 
-class ManualCollageScreenController extends ScreenControllerBase<ManualCollageScreenViewModel> with UiLoggy {
+class ManualCollageScreenController extends ScreenControllerBase<ManualCollageScreenViewModel> {
 
   // Initialization/Deinitialization
 
@@ -40,11 +39,11 @@ class ManualCollageScreenController extends ScreenControllerBase<ManualCollageSc
     PhotosManager.instance.reset(advance: false);
     viewModel.numSelected = 0;
     selectedPhotos.clear();
-    loggy.debug("Cleared selection");
+    logDebug("Cleared selection");
   }
 
   Future<void> tapPhoto(SelectableImage file) async {
-    loggy.debug("Tapped image #${file.index} (${path.basename(file.file.path)}), selected: ${file.isSelected} at index ${file.selectedIndex}, ctrl: ${viewModel.isControlPressed}, shift: ${viewModel.isShiftPressed}");
+    logDebug("Tapped image #${file.index} (${path.basename(file.file.path)}), selected: ${file.isSelected} at index ${file.selectedIndex}, ctrl: ${viewModel.isControlPressed}, shift: ${viewModel.isShiftPressed}");
 
     if (viewModel.isShiftPressed) {
       final lastSelected = selectedPhotos.last.index;
@@ -113,11 +112,11 @@ class ManualCollageScreenController extends ScreenControllerBase<ManualCollageSc
       format: format,
       jpgQuality: jpgQuality,
     );
-    loggy.debug('captureCollage took ${stopwatch.elapsed}');
+    logDebug('captureCollage took ${stopwatch.elapsed}');
 
     PhotosManager.instance.outputImage = exportImage;
     File? file = await PhotosManager.instance.writeOutput(advance: true);
-    loggy.debug("Saved collage image to disk");
+    logDebug("Saved collage image to disk");
 
     if (viewModel.printOnSave) {
       String jobName = file != null ? path.basenameWithoutExtension(file.path) : "MomentoBooth Collage";

--- a/lib/views/manual_collage_screen/manual_collage_screen_view_model.dart
+++ b/lib/views/manual_collage_screen/manual_collage_screen_view_model.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:fluent_ui/fluent_ui.dart';
-import 'package:loggy/loggy.dart';
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/views/base/screen_view_model_base.dart';
@@ -22,7 +21,7 @@ class SelectableImage {
   });
 }
 
-abstract class ManualCollageScreenViewModelBase extends ScreenViewModelBase with Store, UiLoggy {
+abstract class ManualCollageScreenViewModelBase extends ScreenViewModelBase with Store {
 
   ManualCollageScreenViewModelBase({
     required super.contextAccessor,
@@ -57,13 +56,13 @@ abstract class ManualCollageScreenViewModelBase extends ScreenViewModelBase with
 
   @observable
   bool isSaving = false;
-  
+
   @observable
   ObservableList<SelectableImage> fileList = ObservableList<SelectableImage>();
 
   @action
   Future<void> findImages() async {
-    loggy.debug("Searching for images");
+    logDebug("Searching for images");
     final fileListBefore = await outputDir.list().toList();
     final matchingFiles = fileListBefore.whereType<File>().where((file) => file.path.toLowerCase().endsWith('.jpg'));
 
@@ -72,7 +71,7 @@ abstract class ManualCollageScreenViewModelBase extends ScreenViewModelBase with
     for (var file in matchingFiles) {
       fileList.add(SelectableImage(file: file, index: i++));
     }
-    loggy.debug("Found ${matchingFiles.length} images");
+    logDebug("Found ${matchingFiles.length} images");
   }
 
 }

--- a/lib/views/multi_capture_screen/multi_capture_screen_view_model.dart
+++ b/lib/views/multi_capture_screen/multi_capture_screen_view_model.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/animation.dart';
 import 'package:flutter/services.dart';
-import 'package:loggy/loggy.dart';
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/hardware_control/gphoto2_camera.dart';
 import 'package:momento_booth/hardware_control/photo_capturing/live_view_stream_snapshot_capturer.dart';
@@ -22,7 +21,7 @@ part 'multi_capture_screen_view_model.g.dart';
 
 class MultiCaptureScreenViewModel = MultiCaptureScreenViewModelBase with _$MultiCaptureScreenViewModel;
 
-abstract class MultiCaptureScreenViewModelBase extends ScreenViewModelBase with Store, UiLoggy {
+abstract class MultiCaptureScreenViewModelBase extends ScreenViewModelBase with Store {
 
   late final PhotoCaptureMethod capturer;
   bool flashComplete = false;
@@ -71,7 +70,7 @@ abstract class MultiCaptureScreenViewModelBase extends ScreenViewModelBase with 
       CaptureMethod.liveViewSource => LiveViewStreamSnapshotCapturer(),
       CaptureMethod.sonyImagingEdgeDesktop => SonyRemotePhotoCapture(SettingsManager.instance.settings.hardware.captureLocation),
       CaptureMethod.gPhoto2 => LiveViewManager.instance.gPhoto2Camera!,
-    } as PhotoCaptureMethod;
+    };
     capturer.clearPreviousEvents();
 
     if (autoFocusMsBeforeCapture > 0 && autoFocusDelay > Duration.zero && capturer is GPhoto2Camera) {
@@ -100,7 +99,7 @@ abstract class MultiCaptureScreenViewModelBase extends ScreenViewModelBase with 
       StatsManager.instance.addCapturedPhoto();
       PhotosManager.instance.photos.add(image);
     } catch (error) {
-      loggy.warning(error);
+      logWarning(error);
       final ByteData data = await rootBundle.load('assets/bitmap/capture-error.png');
       PhotosManager.instance.photos.add(PhotoCapture(
         data: data.buffer.asUint8List(),

--- a/lib/views/photo_details_screen/photo_details_screen_controller.dart
+++ b/lib/views/photo_details_screen/photo_details_screen_controller.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:loggy/loggy.dart';
 import 'package:momento_booth/managers/printing_manager.dart';
 import 'package:momento_booth/utils/hardware.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
@@ -7,7 +6,7 @@ import 'package:momento_booth/views/custom_widgets/dialogs/qr_share_dialog.dart'
 import 'package:momento_booth/views/photo_details_screen/photo_details_screen_view_model.dart';
 import 'package:path/path.dart' as path;
 
-class PhotoDetailsScreenController extends ScreenControllerBase<PhotoDetailsScreenViewModel> with UiLoggy {
+class PhotoDetailsScreenController extends ScreenControllerBase<PhotoDetailsScreenViewModel> {
 
   // Initialization/Deinitialization
 
@@ -53,7 +52,7 @@ class PhotoDetailsScreenController extends ScreenControllerBase<PhotoDetailsScre
   Future<void> onClickPrint() async {
     if (!viewModel.printEnabled) return;
 
-    loggy.debug("Printing photo");
+    logDebug("Printing photo");
 
     viewModel
       ..printEnabled = false
@@ -68,7 +67,7 @@ class PhotoDetailsScreenController extends ScreenControllerBase<PhotoDetailsScre
       await PrintingManager.instance.printPdf(jobName, pdfData);
       success = true;
     } catch (e) {
-      loggy.error("Failed to print photo: $e");
+      logError("Failed to print photo: $e");
     }
 
     viewModel.printText = success ? localizations.photoDetailsScreenPrinting : localizations.photoDetailsScreenPrintUnsuccesful;

--- a/lib/views/photo_details_screen/photo_details_screen_view_model.dart
+++ b/lib/views/photo_details_screen/photo_details_screen_view_model.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:loggy/loggy.dart';
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
@@ -13,7 +12,7 @@ part 'photo_details_screen_view_model.g.dart';
 
 class PhotoDetailsScreenViewModel = PhotoDetailsScreenViewModelBase with _$PhotoDetailsScreenViewModel;
 
-abstract class PhotoDetailsScreenViewModelBase extends ScreenViewModelBase with Store, UiLoggy {
+abstract class PhotoDetailsScreenViewModelBase extends ScreenViewModelBase with Store {
 
   final String photoId;
 
@@ -21,7 +20,7 @@ abstract class PhotoDetailsScreenViewModelBase extends ScreenViewModelBase with 
     required super.contextAccessor,
     required this.photoId,
   });
-  
+
   Directory get outputDir => Directory(SettingsManager.instance.settings.output.localFolder);
   File? get file => File(path.join(outputDir.path, photoId));
 
@@ -43,7 +42,7 @@ abstract class PhotoDetailsScreenViewModelBase extends ScreenViewModelBase with 
   String get ffSendUrl => SettingsManager.instance.settings.output.firefoxSendServerUrl;
 
   Future<void> uploadPhotoToSend() async {
-    loggy.debug("Uploading ${file!.path}");
+    logDebug("Uploading ${file!.path}");
 
     String basename = path.basename(file!.path);
     Stream<FfSendTransferProgress> stream = ffsendUploadFile(filePath: file!.path, hostUrl: ffSendUrl, downloadFilename: basename);
@@ -53,7 +52,7 @@ abstract class PhotoDetailsScreenViewModelBase extends ScreenViewModelBase with 
 
     stream.listen((event) async {
       if (event.isFinished) {
-        loggy.debug("Upload complete: ${event.downloadUrl}");
+        logDebug("Upload complete: ${event.downloadUrl}");
 
         await Future.delayed(const Duration(milliseconds: 500));
         _qrUrl = event.downloadUrl;
@@ -61,11 +60,11 @@ abstract class PhotoDetailsScreenViewModelBase extends ScreenViewModelBase with 
 
         StatsManager.instance.addUploadedPhoto();
       } else {
-        loggy.debug("Uploading: ${event.transferredBytes}/${event.totalBytes} bytes");
+        logDebug("Uploading: ${event.transferredBytes}/${event.totalBytes} bytes");
         _uploadProgress = event.transferredBytes / (event.totalBytes ?? 0);
       }
     }).onError((x) async {
-      loggy.error("Upload failed, file path: ${file!.path}", x);
+      logError("Upload failed, file path: ${file!.path}", x);
       await Future.delayed(const Duration(seconds: 1));
       _uploadProgress = null;
       _uploadFailed = true;

--- a/lib/views/settings_screen/settings_screen_controller.dart
+++ b/lib/views/settings_screen/settings_screen_controller.dart
@@ -1,14 +1,13 @@
 import 'dart:io';
 
 import 'package:fluent_ui/fluent_ui.dart';
-import 'package:loggy/loggy.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/models/maker_note_data.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
 import 'package:momento_booth/views/settings_screen/settings_screen_view_model.dart';
 
-class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewModel> with UiLoggy {
+class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewModel> {
 
   final comboboxKey = GlobalKey<ComboBoxState>(debugLabel: 'Combobox Key');
 
@@ -88,10 +87,10 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
       format: format,
       jpgQuality: jpgQuality,
     );
-    loggy.debug('captureCollage took ${stopwatch.elapsed}');
+    logDebug('captureCollage took ${stopwatch.elapsed}');
 
     File? file = await PhotosManager.instance.writeOutput(advance: true);
-    loggy.debug("Wrote template debug export output to ${file?.path}");
+    logDebug("Wrote template debug export output to ${file?.path}");
   }
 
   void onCaptureDelaySecondsChanged(int? captureDelaySeconds) {
@@ -245,7 +244,7 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
           currentList[printerIndex] = printerName;
         }
       }
-      loggy.debug("Setting CUPS printer list to $currentList");
+      logDebug("Setting CUPS printer list to $currentList");
       viewModel.updateSettings((settings) => settings.copyWith.hardware(cupsPrinterQueues: currentList));
     }
   }
@@ -287,7 +286,7 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
           currentList[printerIndex] = printerName;
         }
       }
-      loggy.debug("Setting Flutter printing printerlist to $currentList");
+      logDebug("Setting Flutter printing printerlist to $currentList");
       viewModel.updateSettings((settings) => settings.copyWith.hardware(flutterPrintingPrinterNames: currentList));
     }
   }

--- a/lib/views/settings_screen/settings_screen_view.dart
+++ b/lib/views/settings_screen/settings_screen_view.dart
@@ -1,4 +1,5 @@
 import 'package:fluent_ui/fluent_ui.dart';
+import 'package:flutter/material.dart' show ScaffoldMessenger;
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/mqtt_manager.dart';
@@ -110,8 +111,17 @@ class SettingsScreenView extends ScreenViewBase<SettingsScreenViewModel, Setting
   Widget get _log {
     return Padding(
       padding: const EdgeInsets.all(16.0),
-      child: TalkerView(
-        talker: getIt<Talker>(),
+      child: ScaffoldMessenger(
+        child: TalkerScreen(
+          talker: getIt<Talker>(),
+          theme: TalkerScreenTheme(
+            backgroundColor: FluentTheme.of(context).navigationPaneTheme.backgroundColor!,
+            textColor: FluentTheme.of(context).typography.body!.color!,
+            cardColor: FluentTheme.of(context).cardColor,
+          ),
+          appBarLeading: const SizedBox(),
+          appBarTitle: '',
+        ),
       ),
     );
   }

--- a/lib/views/settings_screen/settings_screen_view.dart
+++ b/lib/views/settings_screen/settings_screen_view.dart
@@ -1,6 +1,6 @@
 import 'package:fluent_ui/fluent_ui.dart';
-import 'package:flutter_loggy/flutter_loggy.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
+import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/mqtt_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
 import 'package:momento_booth/models/settings.dart';
@@ -23,6 +23,7 @@ import 'package:momento_booth/views/settings_screen/widgets/number_input_card.da
 import 'package:momento_booth/views/settings_screen/widgets/secret_input_card.dart';
 import 'package:momento_booth/views/settings_screen/widgets/text_display_card.dart';
 import 'package:momento_booth/views/settings_screen/widgets/text_input_card.dart';
+import 'package:talker_flutter/talker_flutter.dart';
 
 part 'settings_screen_view.debug.dart';
 part 'settings_screen_view.face_recognition.dart';
@@ -107,9 +108,11 @@ class SettingsScreenView extends ScreenViewBase<SettingsScreenViewModel, Setting
   }
 
   Widget get _log {
-    return const Padding(
-      padding: EdgeInsets.all(16.0),
-      child: LoggyStreamWidget(),
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: TalkerView(
+        talker: getIt<Talker>(),
+      ),
     );
   }
 

--- a/lib/views/share_screen/share_screen_controller.dart
+++ b/lib/views/share_screen/share_screen_controller.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:loggy/loggy.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/managers/printing_manager.dart';
 import 'package:momento_booth/managers/sfx_manager.dart';
@@ -15,7 +14,7 @@ import 'package:momento_booth/views/share_screen/share_screen_view_model.dart';
 import 'package:momento_booth/views/start_screen/start_screen.dart';
 import 'package:path/path.dart' as path;
 
-class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> with UiLoggy, PrinterStatusDialogMixin<ShareScreenViewModel> {
+class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> with PrinterStatusDialogMixin<ShareScreenViewModel> {
 
   // Initialization/Deinitialization
 
@@ -31,7 +30,7 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> w
   }
 
   void onClickPrev() {
-    loggy.debug("Clicked prev");
+    logDebug("Clicked prev");
     if (PhotosManager.instance.captureMode == CaptureMode.single) {
       PhotosManager.instance.reset(advance: false);
       StatsManager.instance.addRetake();
@@ -74,7 +73,7 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> w
   Future<void> onClickPrint() async {
     if (!viewModel.printEnabled) return;
 
-    loggy.debug("Printing photo");
+    logDebug("Printing photo");
 
     viewModel
       ..printEnabled = false
@@ -89,7 +88,7 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> w
       await PrintingManager.instance.printPdf(jobName, pdfData);
       success = true;
     } catch (e) {
-      loggy.error("Failed to print photo: $e");
+      logError("Failed to print photo: $e");
     }
 
     viewModel.printText = success ? localizations.shareScreenPrinting : localizations.shareScreenPrintUnsuccesful;

--- a/lib/views/share_screen/share_screen_view_model.dart
+++ b/lib/views/share_screen/share_screen_view_model.dart
@@ -4,7 +4,6 @@ import 'dart:typed_data';
 import 'package:confetti/confetti.dart';
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:intl/intl.dart';
-import 'package:loggy/loggy.dart';
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
@@ -17,7 +16,7 @@ part 'share_screen_view_model.g.dart';
 
 class ShareScreenViewModel = ShareScreenViewModelBase with _$ShareScreenViewModel;
 
-abstract class ShareScreenViewModelBase extends ScreenViewModelBase with Store, UiLoggy {
+abstract class ShareScreenViewModelBase extends ScreenViewModelBase with Store {
 
   ShareScreenViewModelBase({
     required super.contextAccessor,
@@ -65,7 +64,7 @@ abstract class ShareScreenViewModelBase extends ScreenViewModelBase with Store, 
     _file ??= await PhotosManager.instance.getOutputImageAsTempFile();
     final ext = SettingsManager.instance.settings.output.exportFormat.name.toLowerCase();
 
-    loggy.debug("Uploading ${_file!.path}");
+    logDebug("Uploading ${_file!.path}");
 
     // HHmmss string
     DateFormat formatter = DateFormat('HHmmss');
@@ -77,7 +76,7 @@ abstract class ShareScreenViewModelBase extends ScreenViewModelBase with Store, 
 
     stream.listen((event) async {
       if (event.isFinished) {
-        loggy.debug("Upload complete: ${event.downloadUrl}");
+        logDebug("Upload complete: ${event.downloadUrl}");
 
         await Future.delayed(const Duration(milliseconds: 500));
         _qrUrl = event.downloadUrl;
@@ -85,11 +84,11 @@ abstract class ShareScreenViewModelBase extends ScreenViewModelBase with Store, 
 
         StatsManager.instance.addUploadedPhoto();
       } else {
-        loggy.debug("Uploading: ${event.transferredBytes}/${event.totalBytes} bytes");
+        logDebug("Uploading: ${event.transferredBytes}/${event.totalBytes} bytes");
         _uploadProgress = event.transferredBytes / (event.totalBytes ?? 0);
       }
     }).onError((x) async {
-      loggy.error("Upload failed, file path: ${_file!.path}", x);
+      logError("Upload failed, file path: ${_file!.path}", x);
       await Future.delayed(const Duration(seconds: 1));
       _uploadProgress = null;
       _uploadFailed = true;

--- a/lib/views/start_screen/start_screen_controller.dart
+++ b/lib/views/start_screen/start_screen_controller.dart
@@ -1,11 +1,10 @@
-import 'package:loggy/loggy.dart';
 import 'package:momento_booth/views/base/printer_status_dialog_mixin.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
 import 'package:momento_booth/views/choose_capture_mode_screen/choose_capture_mode_screen.dart';
 import 'package:momento_booth/views/gallery_screen/gallery_screen.dart';
 import 'package:momento_booth/views/start_screen/start_screen_view_model.dart';
 
-class StartScreenController extends ScreenControllerBase<StartScreenViewModel> with UiLoggy, PrinterStatusDialogMixin<StartScreenViewModel> {
+class StartScreenController extends ScreenControllerBase<StartScreenViewModel> with PrinterStatusDialogMixin<StartScreenViewModel> {
 
   // Initialization/Deinitialization
 

--- a/lib/widgetbook.dart
+++ b/lib/widgetbook.dart
@@ -42,6 +42,7 @@ class WidgetbookApp extends StatelessWidget {
             AppLocalizations.delegate,
             GlobalMaterialLocalizations.delegate,
             GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
             FluentLocalizations.delegate,
           ],
           supportedLocales: const [

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -12,6 +12,7 @@
 #include <screen_retriever/screen_retriever_plugin.h>
 #include <sentry_flutter/sentry_flutter_plugin.h>
 #include <texture_rgba_renderer/texture_rgba_renderer_plugin.h>
+#include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_manager/window_manager_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
@@ -33,6 +34,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) texture_rgba_renderer_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "TextureRgbaRendererPlugin");
   texture_rgba_renderer_plugin_register_with_registrar(texture_rgba_renderer_registrar);
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
   g_autoptr(FlPluginRegistrar) window_manager_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "WindowManagerPlugin");
   window_manager_plugin_register_with_registrar(window_manager_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -9,6 +9,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   screen_retriever
   sentry_flutter
   texture_rgba_renderer
+  url_launcher_linux
   window_manager
 )
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -14,6 +14,7 @@ import path_provider_foundation
 import printing
 import screen_retriever
 import sentry_flutter
+import share_plus
 import texture_rgba_renderer
 import window_manager
 
@@ -27,6 +28,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PrintingPlugin.register(with: registry.registrar(forPlugin: "PrintingPlugin"))
   ScreenRetrieverPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverPlugin"))
   SentryFlutterPlugin.register(with: registry.registrar(forPlugin: "SentryFlutterPlugin"))
+  SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   TextureRgbaRendererPlugin.register(with: registry.registrar(forPlugin: "TextureRgbaRendererPlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -19,13 +19,13 @@ PODS:
     - FlutterMacOS
   - screen_retriever (0.0.1):
     - FlutterMacOS
-  - Sentry/HybridSDK (8.21.0):
-    - SentryPrivate (= 8.21.0)
-  - sentry_flutter (7.20.0):
+  - Sentry/HybridSDK (8.25.2)
+  - sentry_flutter (8.2.0):
     - Flutter
     - FlutterMacOS
-    - Sentry/HybridSDK (= 8.21.0)
-  - SentryPrivate (8.21.0)
+    - Sentry/HybridSDK (= 8.25.2)
+  - share_plus (0.0.1):
+    - FlutterMacOS
   - texture_rgba_renderer (0.0.1):
     - FlutterMacOS
   - window_manager (0.2.0):
@@ -43,13 +43,13 @@ DEPENDENCIES:
   - rust_lib_momento_booth (from `Flutter/ephemeral/.symlinks/plugins/rust_lib_momento_booth/macos`)
   - screen_retriever (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever/macos`)
   - sentry_flutter (from `Flutter/ephemeral/.symlinks/plugins/sentry_flutter/macos`)
+  - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
   - texture_rgba_renderer (from `Flutter/ephemeral/.symlinks/plugins/texture_rgba_renderer/macos`)
   - window_manager (from `Flutter/ephemeral/.symlinks/plugins/window_manager/macos`)
 
 SPEC REPOS:
   trunk:
     - Sentry
-    - SentryPrivate
 
 EXTERNAL SOURCES:
   audio_session:
@@ -74,6 +74,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever/macos
   sentry_flutter:
     :path: Flutter/ephemeral/.symlinks/plugins/sentry_flutter/macos
+  share_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/share_plus/macos
   texture_rgba_renderer:
     :path: Flutter/ephemeral/.symlinks/plugins/texture_rgba_renderer/macos
   window_manager:
@@ -81,18 +83,18 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   audio_session: dea1f41890dbf1718f04a56f1d6150fd50039b72
-  file_selector_macos: 468fb6b81fac7c0e88d71317f3eec34c3b008ff9
-  flutter_secure_storage_macos: d56e2d218c1130b262bef8b4a7d64f88d7f9c9ea
+  file_selector_macos: 54fdab7caa3ac3fc43c9fac4d7d8d231277f8cf2
+  flutter_secure_storage_macos: 59459653abe1adb92abbc8ea747d79f8d19866c9
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   just_audio: 9b67ca7b97c61cfc9784ea23cd8cc55eb226d489
   package_info_plus: fa739dd842b393193c5ca93c26798dff6e3d0e0c
-  path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   printing: 1dd6a1fce2209ec240698e2439a4adbb9b427637
   rust_lib_momento_booth: 9aac42ff9f5beed95777582b9ed9e72d458190ff
   screen_retriever: 59634572a57080243dd1bf715e55b6c54f241a38
-  Sentry: ebc12276bd17613a114ab359074096b6b3725203
-  sentry_flutter: df6e28477322fc5202bbe20aafdd7404b6e97729
-  SentryPrivate: d651efb234cf385ec9a1cdd3eff94b5e78a0e0fe
+  Sentry: 51b056d96914a741f63eca774d118678b1eb05a1
+  sentry_flutter: e8397d13e297a5d4b6be8a752e33140b21c5cc97
+  share_plus: 36537c04ce0c3e3f5bd297ce4318b6d5ee5fd6cf
   texture_rgba_renderer: cbed959a3c127122194a364e14b8577bd62dc8f2
   window_manager: 3a1844359a6295ab1e47659b1a777e36773cd6e8
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -33,6 +33,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.2"
+  ansicolor:
+    dependency: transitive
+    description:
+      name: ansicolor
+      sha256: "8bf17a8ff6ea17499e40a2d2542c2f481cd7615760c6d34065cb22bfd22e6880"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   archive:
     dependency: transitive
     description:
@@ -459,14 +467,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_loggy:
-    dependency: "direct main"
-    description:
-      name: flutter_loggy
-      sha256: "21b515977deefe37817cce35b0e420c7cde930b9dcfdcbeb05730ed24ee74e3a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.2"
   flutter_mobx:
     dependency: "direct main"
     description:
@@ -609,10 +609,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "81f94e16d7063b60f0da3a79f872e140d6518f306749303bf981abd7d6b46734"
+      sha256: "7685acd06244ba4be60f455c5cafe5790c63dc91fc03f7385b1e922a6b85b17c"
       url: "https://pub.dev"
     source: hosted
-    version: "14.1.0"
+    version: "14.1.1"
   graphs:
     dependency: transitive
     description:
@@ -621,6 +621,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
+  group_button:
+    dependency: transitive
+    description:
+      name: group_button
+      sha256: "0610fcf28ed122bfb4b410fce161a390f7f2531d55d1d65c5375982001415940"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.3.4"
   html:
     dependency: transitive
     description:
@@ -797,14 +805,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
-  loggy:
-    dependency: "direct main"
-    description:
-      name: loggy
-      sha256: "981e03162bbd3a5a843026f75f73d26e4a0d8aa035ae060456ca7b30dfd1e339"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.3"
   lottie:
     dependency: "direct main"
     description:
@@ -1128,10 +1128,10 @@ packages:
     dependency: "direct main"
     description:
       name: screenshot
-      sha256: "5488135006b34529bf3765a7b1900ca94ccafca300c573550a0474a7162ebf95"
+      sha256: "63817697a7835e6ce82add4228e15d233b74d42975c143ad8cfe07009fab866b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "3.0.0"
   scroll_pos:
     dependency: transitive
     description:
@@ -1144,18 +1144,34 @@ packages:
     dependency: transitive
     description:
       name: sentry
-      sha256: "1d2952d40b99da0dc4bf3ba4797e3985dd60cc61a13d0a1d2c62b02f6528441a"
+      sha256: fd1fbfe860c05f5c52820ec4dbf2b6473789e83ead26cfc18bca4fe80bf3f008
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.0"
+    version: "8.2.0"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
-      sha256: "848aaccfc75f1d35d5f7e5230770761f1b2a33e604f24498200566443da1470a"
+      sha256: c64f0aec5332bec87083b61514d1b6b29e435b9045d03ce1575861192b9a5680
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.0"
+    version: "8.2.0"
+  share_plus:
+    dependency: transitive
+    description:
+      name: share_plus
+      sha256: ef3489a969683c4f3d0239010cc8b7a2a46543a8d139e111c06c558875083544
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.0"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: "0f9e4418835d1b2c3ae78fdb918251959106cefdbc4dd43526e182f80e82f6d4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   shelf:
     dependency: transitive
     description:
@@ -1257,6 +1273,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0+1"
+  talker:
+    dependency: "direct main"
+    description:
+      name: talker
+      sha256: edd1ec2d1e941ac1569f27d820cd896e0dc9bc4e4160963e3c8c192079f08da0
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.0"
+  talker_flutter:
+    dependency: "direct main"
+    description:
+      name: talker_flutter
+      sha256: "8b10ea148e16410abc950ab596a9cb9b2ae4380640dec9a88dc80503f41902b8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.0"
+  talker_logger:
+    dependency: transitive
+    description:
+      name: talker_logger
+      sha256: "777c62bb8019ec26f5b99626fe0bd28e169bae724ffde8438a5e4ad28e2c20df"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.0"
   term_glyph:
     dependency: transitive
     description:
@@ -1322,6 +1362,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.2"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: ab360eb661f8879369acac07b6bb3ff09d9471155357da8443fd5d3cf7363811
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "8d9e750d8c9338601e709cd0885f95825086bd8b642547f26bda435aade95d8a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: ecf9725510600aa2bb6d7ddabe16357691b6d2805f66216a97d1b881e21beff7
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
   uuid:
     dependency: transitive
     description:
@@ -1468,4 +1540,4 @@ packages:
     version: "3.1.2"
 sdks:
   dart: ">=3.4.0 <4.0.0"
-  flutter: ">=3.20.0-7.0.pre.48"
+  flutter: ">=3.22.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -881,10 +881,10 @@ packages:
     dependency: "direct main"
     description:
       name: mqtt5_client
-      sha256: f8ec6da6faf84477d87eb87f783c73cd952e1670ff999065681f0d87d288a83b
+      sha256: "9259f7493dbb7f230673761be653a8b12f9476e4a791944cc7983a5c11767b30"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.4"
+    version: "4.2.5"
   nested:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -133,10 +133,10 @@ packages:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "0343061a33da9c5810b2d6cee51945127d8f4c060b7fbdd9d54917f0a3feaaa1"
+      sha256: "79b2aef6ac2ed00046867ed354c88778c9c0f029df8a20fe10b5436826721ef9"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "4.0.2"
   build_resolvers:
     dependency: transitive
     description:
@@ -149,10 +149,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "3ac61a79bfb6f6cc11f693591063a7f19a7af628dc52f141743edac5c16e8c22"
+      sha256: "1414d6d733a85d8ad2f1dfcb3ea7945759e35a123cb99ccfac75d0758f75edfa"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.9"
+    version: "2.4.10"
   build_runner_core:
     dependency: transitive
     description:
@@ -365,10 +365,10 @@ packages:
     dependency: transitive
     description:
       name: file_selector_ios
-      sha256: "7160121e434910ec23717bde3a0c514ca039e8c97b791ff35d1786da38abcb4a"
+      sha256: "2bacc6d8725b88f4124c2a780fbf939e96eb1f804362867be4f617dcccec959c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.2"
+    version: "0.5.2+1"
   file_selector_linux:
     dependency: transitive
     description:
@@ -421,18 +421,18 @@ packages:
     dependency: "direct main"
     description:
       name: flex_color_picker
-      sha256: "5c846437069fb7afdd7ade6bf37e628a71d2ab0787095ddcb1253bf9345d5f3a"
+      sha256: "31b27677d8d8400e4cff5edb3f189f606dd964d608779b6ae1b7ddad37ea48c6"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.1"
+    version: "3.5.0"
   flex_seed_scheme:
     dependency: transitive
     description:
       name: flex_seed_scheme
-      sha256: "4cee2f1d07259f77e8b36f4ec5f35499d19e74e17c7dce5b819554914082bc01"
+      sha256: fb66cdb8ca89084e79efcad2bc2d9deb144666875116f08cdd8d9f8238c8b3ab
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "2.0.0"
   fluent_ui:
     dependency: "direct main"
     description:
@@ -479,10 +479,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_rust_bridge
-      sha256: "2bf072117fe975e18aa418234572aa6c60a0513141dc4239a5409eebd0a6a597"
+      sha256: "43c2c170e7120df691fb31c1c06c498784ee7cae9b495257c72c934cf4dadf3e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0-dev.33"
+    version: "2.0.0-dev.34"
   flutter_scroll_shadow:
     dependency: "direct main"
     description:
@@ -495,10 +495,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: c0f402067fb0498934faa6bddd670de0a3db45222e2ca9a068c6177c9a2360a4
+      sha256: "8496a89eea74e23f92581885f876455d9d460e71201405dffe5f55dfe1155864"
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.1"
+    version: "9.2.1"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
@@ -511,18 +511,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage_macos
-      sha256: "8cfa53010a294ff095d7be8fa5bb15f2252c50018d69c5104851303f3ff92510"
+      sha256: b768a7dab26d6186b68e2831b3104f8968154f0f4fdbf66e7c2dd7bdf299daaf
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:
       name: flutter_secure_storage_platform_interface
-      sha256: "301f67ee9b87f04aef227f57f13f126fa7b13543c8e7a93f25c5d2d534c28a4a"
+      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   flutter_secure_storage_web:
     dependency: transitive
     description:
@@ -609,10 +609,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "7685acd06244ba4be60f455c5cafe5790c63dc91fc03f7385b1e922a6b85b17c"
+      sha256: aa073287b8f43553678e6fa9e8bb9c83212ff76e09542129a8099bbc8db4df65
       url: "https://pub.dev"
     source: hosted
-    version: "14.1.1"
+    version: "14.1.2"
   graphs:
     dependency: transitive
     description:
@@ -721,10 +721,10 @@ packages:
     dependency: "direct main"
     description:
       name: just_audio
-      sha256: b7cb6bbf3750caa924d03f432ba401ec300fd90936b3f73a9b33d58b1e96286b
+      sha256: "5abfab1d199e01ab5beffa61b3e782350df5dad036cb8c83b79fa45fc656614e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.37"
+    version: "0.9.38"
   just_audio_mpv:
     dependency: "direct main"
     description:
@@ -737,18 +737,18 @@ packages:
     dependency: transitive
     description:
       name: just_audio_platform_interface
-      sha256: c3dee0014248c97c91fe6299edb73dc4d6c6930a2f4f713579cd692d9e47f4a1
+      sha256: "0243828cce503c8366cc2090cefb2b3c871aa8ed2f520670d76fd47aa1ab2790"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.2"
+    version: "4.3.0"
   just_audio_web:
     dependency: transitive
     description:
       name: just_audio_web
-      sha256: "134356b0fe3d898293102b33b5fd618831ffdc72bb7a1b726140abdf22772b70"
+      sha256: "0edb481ad4aa1ff38f8c40f1a3576013c3420bf6669b686fe661627d49bc606c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.11"
   just_audio_windows:
     dependency: "direct main"
     description:
@@ -809,10 +809,10 @@ packages:
     dependency: "direct main"
     description:
       name: lottie
-      sha256: "46def1e76c4fbfd4643e823980112cfe94a2ba1d9152fe54701c0bf30be4f4cd"
+      sha256: "6a24ade5d3d918c306bb1c21a6b9a04aab0489d51a2582522eea820b4093b62b"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   matcher:
     dependency: transitive
     description:
@@ -1184,10 +1184,10 @@ packages:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
+      sha256: "073c147238594ecd0d193f3456a5fe91c4b0abbcc68bf5cd95b36c4e194ac611"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -1466,14 +1466,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "217f49b5213796cb508d6a942a5dc604ce1cb6a0a6b3d8cb3f0c314f0ecea712"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: "58c6666b342a38816b2e7e50ed0f1e261959630becd4c879c4f26bfa14aa5a42"
+      sha256: a2d56211ee4d35d9b344d9d4ce60f362e4f5d1aafb988302906bd732bc731276
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.5"
+    version: "3.0.0"
   widgetbook:
     dependency: "direct main"
     description:
@@ -1502,18 +1510,18 @@ packages:
     dependency: "direct main"
     description:
       name: win32
-      sha256: "0eaf06e3446824099858367950a813472af675116bf63f008a4c2a75ae13e9cb"
+      sha256: a79dbe579cb51ecd6d30b17e0cae4e0ea15e2c0e66f69ad4198f22a6789e94f4
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.0"
+    version: "5.5.1"
   window_manager:
     dependency: "direct main"
     description:
       name: window_manager
-      sha256: b3c895bdf936c77b83c5254bec2e6b3f066710c1f89c38b20b8acc382b525494
+      sha256: "8699323b30da4cdbe2aa2e7c9de567a6abd8a97d9a5c850a3c86dcd0b34bbfbf"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.8"
+    version: "0.3.9"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -438,11 +438,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_driver:
-    dependency: transitive
-    description: flutter
-    source: sdk
-    version: "0.0.0"
   flutter_layout_grid:
     dependency: "direct main"
     description:
@@ -594,11 +589,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
-  fuchsia_remote_debug_protocol:
-    dependency: transitive
-    description: flutter
-    source: sdk
-    version: "0.0.0"
   get_it:
     dependency: "direct main"
     description:
@@ -679,19 +669,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
-  integration_test:
-    dependency: "direct dev"
-    description: flutter
-    source: sdk
-    version: "0.0.0"
   intl:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.1"
+    version: "0.19.0"
   io:
     dependency: transitive
     description:
@@ -768,26 +753,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lemberfpsmonitor:
     dependency: "direct main"
     description:
@@ -856,10 +841,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -1008,10 +993,10 @@ packages:
     dependency: transitive
     description:
       name: pdf_widget_wrapper
-      sha256: "9c3ca36e5000c9682d52bbdc486867ba7c5ee4403d1a5d6d03ed72157753377b"
+      sha256: c930860d987213a3d58c7ec3b7ecf8085c3897f773e8dc23da9cae60a5d6d0f5
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   petitparser:
     dependency: transitive
     description:
@@ -1060,14 +1045,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.12.0"
-  process:
-    dependency: transitive
-    description:
-      name: process
-      sha256: "21e54fd2faf1b5bdd5102afd25012184a6793927648ea81eea80552ac9405b32"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.0.2"
   provider:
     dependency: transitive
     description:
@@ -1272,14 +1249,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
-  sync_http:
-    dependency: transitive
-    description:
-      name: sync_http
-      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.1"
   synchronized:
     dependency: "direct main"
     description:
@@ -1300,10 +1269,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   texture_rgba_renderer:
     dependency: "direct main"
     description:
@@ -1397,10 +1366,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   watcher:
     dependency: transitive
     description:
@@ -1433,14 +1402,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.5"
-  webdriver:
-    dependency: transitive
-    description:
-      name: webdriver
-      sha256: "003d7da9519e1e5f329422b36c4dcdf18d7d2978d1ba099ea4e45ba490ed845e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.3"
   widgetbook:
     dependency: "direct main"
     description:
@@ -1506,5 +1467,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.19.0"
+  dart: ">=3.4.0 <4.0.0"
+  flutter: ">=3.20.0-7.0.pre.48"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -81,7 +81,7 @@ dependencies:
   # Networking
   http: 1.2.1
   http_parser: 4.0.2
-  mqtt5_client: 4.2.4
+  mqtt5_client: 4.2.5
 
   # Misc
   get_it: 7.7.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,16 +5,14 @@ publish_to: "none"
 version: 0.8.4+92
 
 environment:
-  sdk: ">=3.2.0 <4.0.0"
+  sdk: ">=3.4.0 <4.0.0"
 
 dependencies:
-  flutter:
-    sdk: flutter
+  flutter: {sdk: flutter}
 
   # i18n
-  flutter_localizations:
-    sdk: flutter
-  intl: ^0.18.1
+  flutter_localizations: { sdk: flutter }
+  intl: any
 
   # UI
   auto_size_text: 3.0.0
@@ -87,7 +85,7 @@ dependencies:
 
   # Misc
   get_it: 7.7.0
-  meta: ^1.11.0
+  meta: any
   synchronized: 3.1.0+1
   collection: 1.18.0
   dart_casing: 3.0.1
@@ -113,8 +111,6 @@ dev_dependencies:
 
   # Code generation
   build_runner: 2.4.9
-  integration_test:
-    sdk: flutter
 
 flutter:
   uses-material-design: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   # UI
   auto_size_text: 3.0.0
   fluent_ui: 4.8.7
-  go_router: 14.1.1
+  go_router: 14.1.2
   flutter_svg: 2.0.10+1
   animated_text_kit: 4.2.2
   figma_squircle: 0.5.3
@@ -28,12 +28,12 @@ dependencies:
   wave: 0.2.2
   texture_rgba_renderer:
     git: https://github.com/h3x4d3c1m4l/flutter_texture_rgba_renderer
-  lottie: 3.1.1
+  lottie: 3.1.2
   font_awesome_flutter: 10.7.0
   smooth_scroll_multiplatform: 1.0.8
   widgetbook: 3.7.1
   widgetbook_annotation: 3.1.0
-  flex_color_picker: 3.4.1
+  flex_color_picker: 3.5.0
 
   # Printscreen/Image processing
   screenshot: 3.0.0
@@ -51,7 +51,7 @@ dependencies:
   rust_lib_momento_booth:
     path: rust_builder
   ffi: 2.1.2
-  flutter_rust_bridge: 2.0.0-dev.33
+  flutter_rust_bridge: 2.0.0-dev.34
 
   # Printing
   printing: 5.12.0
@@ -60,9 +60,9 @@ dependencies:
   # System
   path_provider: 2.1.3
   path: ^1.9.0
-  window_manager: 0.3.8
+  window_manager: 0.3.9
   file_selector: 1.0.3
-  win32: 5.5.0
+  win32: 5.5.1
 
   # Log and error handling
   talker: 4.2.0
@@ -70,12 +70,12 @@ dependencies:
   sentry_flutter: 8.2.0
 
   # Sound output
-  just_audio: 0.9.37
+  just_audio: 0.9.38
   just_audio_windows: 0.2.1
   just_audio_mpv: 0.1.7
 
   # Storage
-  flutter_secure_storage: 9.1.1
+  flutter_secure_storage: 9.2.1
   toml: 0.15.0
 
   # Networking
@@ -110,7 +110,7 @@ dev_dependencies:
   json_serializable: 6.8.0
 
   # Code generation
-  build_runner: 2.4.9
+  build_runner: 2.4.10
 
 flutter:
   uses-material-design: true
@@ -129,26 +129,3 @@ flutter:
       fonts:
         - asset: assets/fonts/brandon_grotesque/Brandon_light.otf
           weight: 300
-
-scripts:
-  run: rps install all && rps generate all
-  install:
-    all: rps install flutter && rps install cargo-expand && rps install flutter_rust_bridge_codegen && rps install deps
-    flutter: fvm install
-    cargo-expand: cargo install cargo-expand
-    flutter_rust_bridge_codegen: cargo install flutter_rust_bridge_codegen --version 2.0.0-dev.33
-    deps: fvm flutter pub get
-  clean:
-    rust_bridge: git clean -xfd lib/src
-  generate:
-    all: rps generate l10n && rps generate rust_bridge
-    l10n: fvm flutter gen-l10n
-    rust_bridge: rps clean rust_bridge && flutter_rust_bridge_codegen generate
-    build_runner_targets: fvm dart run build_runner build --delete-conflicting-outputs
-  update:
-    rust-install: rustup update
-  docs:
-    install-deps: cargo install mdbook mdbook-mermaid mdbook-admonish
-    build:
-      $before: $docs install-deps
-      $script: mdbook build documentation

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   # UI
   auto_size_text: 3.0.0
   fluent_ui: 4.8.7
-  go_router: 14.1.0
+  go_router: 14.1.1
   flutter_svg: 2.0.10+1
   animated_text_kit: 4.2.2
   figma_squircle: 0.5.3
@@ -36,7 +36,7 @@ dependencies:
   flex_color_picker: 3.4.1
 
   # Printscreen/Image processing
-  screenshot: 2.3.0
+  screenshot: 3.0.0
   image: 4.1.7
 
   # MVC
@@ -65,9 +65,9 @@ dependencies:
   win32: 5.5.0
 
   # Log and error handling
-  loggy: 2.0.3
-  flutter_loggy: 2.0.2
-  sentry_flutter: 8.1.0
+  talker: 4.2.0
+  talker_flutter: 4.2.0
+  sentry_flutter: 8.2.0
 
   # Sound output
   just_audio: 0.9.37

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "arbitrary"
@@ -110,7 +110,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -189,7 +189,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "libc",
- "miniz_oxide 0.7.2",
+ "miniz_oxide 0.7.3",
  "object",
  "rustc-demangle",
 ]
@@ -256,7 +256,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.61",
+ "syn 2.0.64",
  "which",
 ]
 
@@ -346,9 +346,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
+checksum = "78834c15cb5d5efe3452d58b1e8ba890dd62d21907f867f383358198e56ebca5"
 
 [[package]]
 name = "byteorder"
@@ -767,7 +767,7 @@ checksum = "51aac4c99b2e6775164b412ea33ae8441b2fde2dbf05a20bc0052a63d08c475b"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -857,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
 name = "encoding_rs"
@@ -879,7 +879,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -890,7 +890,7 @@ checksum = "ba7795da175654fe16979af73f81f26a8ea27638d8d9823d317016888a63dc4c"
 dependencies = [
  "num-traits",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -929,7 +929,7 @@ dependencies = [
  "flume 0.11.0",
  "half",
  "lebe",
- "miniz_oxide 0.7.2",
+ "miniz_oxide 0.7.3",
  "rayon-core",
  "smallvec 1.13.2",
  "zune-inflate",
@@ -994,7 +994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.7.2",
+ "miniz_oxide 0.7.3",
 ]
 
 [[package]]
@@ -1021,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "flutter_rust_bridge"
-version = "2.0.0-dev.33"
+version = "2.0.0-dev.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293c86d55bf9b6108482f8574517a8e7e032dd1d9260e1f4801c6180fdd2583c"
+checksum = "8aacad3a820c302fd81c2842ee70ab6f6c61526c39c449e490c6cbe2023ec802"
 dependencies = [
  "allo-isolate",
  "android_logger",
@@ -1049,13 +1049,13 @@ dependencies = [
 
 [[package]]
 name = "flutter_rust_bridge_macros"
-version = "2.0.0-dev.33"
+version = "2.0.0-dev.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d852460bc16316c4491a60e1652612f717764d436f3a97f8f1cc7c3b54d9a0dc"
+checksum = "f5dd5e1d22e85c8978199ebabaeaf66cf452bb3a8f5cb9dcc2c8e14a576ca287"
 dependencies = [
  "hex",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -1172,7 +1172,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -1619,9 +1619,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1634,7 +1634,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -1755,9 +1755,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1792,9 +1792,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "little_exif"
@@ -1803,7 +1803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e89ca7ab10ff03d6badea1c5f3100319610ddf18e8643ece3f07ac66a4fb141"
 dependencies = [
  "crc",
- "miniz_oxide 0.7.2",
+ "miniz_oxide 0.7.3",
  "paste",
 ]
 
@@ -1944,9 +1944,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
 dependencies = [
  "adler",
  "simd-adler32",
@@ -2167,7 +2167,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -2289,7 +2289,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -2442,7 +2442,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -2473,7 +2473,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide 0.7.2",
+ "miniz_oxide 0.7.3",
 ]
 
 [[package]]
@@ -2489,7 +2489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2 1.0.82",
- "syn 2.0.61",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -2532,7 +2532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8021cf59c8ec9c432cfc2526ac6b8aa508ecaf29cd415f271b8406c1b851c3fd"
 dependencies = [
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -3134,22 +3134,22 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.201"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
+checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.201"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
+checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -3165,9 +3165,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
 dependencies = [
  "serde",
 ]
@@ -3416,9 +3416,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.61"
+version = "2.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c993ed8ccba56ae856363b1845da7266a7cb78e1d146c8a32d54b45a8b831fc9"
+checksum = "7ad3dee41f36859875573074334c200d1add8e4a87bb37113ebd31d926b7b11f"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
@@ -3485,22 +3485,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -3725,9 +3725,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.12"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+checksum = "a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -3737,18 +3737,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.12"
+version = "0.22.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
+checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
 dependencies = [
  "indexmap",
  "serde",
@@ -4018,7 +4018,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.64",
  "wasm-bindgen-shared",
 ]
 
@@ -4052,7 +4052,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.64",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4436,7 +4436,7 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.64",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -108,9 +108,9 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
- "proc-macro2 1.0.82",
+ "proc-macro2 1.0.83",
  "quote 1.0.36",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -251,12 +251,12 @@ dependencies = [
  "log 0.4.21",
  "peeking_take_while",
  "prettyplease",
- "proc-macro2 1.0.82",
+ "proc-macro2 1.0.83",
  "quote 1.0.36",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.64",
+ "syn 2.0.65",
  "which",
 ]
 
@@ -380,9 +380,9 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
+checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
 dependencies = [
  "jobserver",
  "libc",
@@ -633,11 +633,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
 dependencies = [
- "crossbeam-utils 0.8.19",
+ "crossbeam-utils 0.8.20",
 ]
 
 [[package]]
@@ -647,7 +647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
  "crossbeam-epoch",
- "crossbeam-utils 0.8.19",
+ "crossbeam-utils 0.8.20",
 ]
 
 [[package]]
@@ -656,7 +656,7 @@ version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "crossbeam-utils 0.8.19",
+ "crossbeam-utils 0.8.20",
 ]
 
 [[package]]
@@ -672,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crunchy"
@@ -710,7 +710,7 @@ checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.82",
+ "proc-macro2 1.0.83",
  "quote 1.0.36",
  "strsim",
  "syn 1.0.109",
@@ -765,9 +765,9 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51aac4c99b2e6775164b412ea33ae8441b2fde2dbf05a20bc0052a63d08c475b"
 dependencies = [
- "proc-macro2 1.0.82",
+ "proc-macro2 1.0.83",
  "quote 1.0.36",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -778,7 +778,7 @@ checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
 dependencies = [
  "darling",
  "derive_builder_core",
- "proc-macro2 1.0.82",
+ "proc-macro2 1.0.83",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -790,7 +790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
 dependencies = [
  "darling",
- "proc-macro2 1.0.82",
+ "proc-macro2 1.0.83",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -802,7 +802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.82",
+ "proc-macro2 1.0.83",
  "quote 1.0.36",
  "rustc_version 0.4.0",
  "syn 1.0.109",
@@ -877,9 +877,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.82",
+ "proc-macro2 1.0.83",
  "quote 1.0.36",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -890,7 +890,7 @@ checksum = "ba7795da175654fe16979af73f81f26a8ea27638d8d9823d317016888a63dc4c"
 dependencies = [
  "num-traits",
  "quote 1.0.36",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1055,7 +1055,7 @@ checksum = "f5dd5e1d22e85c8978199ebabaeaf66cf452bb3a8f5cb9dcc2c8e14a576ca287"
 dependencies = [
  "hex",
  "quote 1.0.36",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1170,9 +1170,9 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
- "proc-macro2 1.0.82",
+ "proc-macro2 1.0.83",
  "quote 1.0.36",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1632,9 +1632,9 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
- "proc-macro2 1.0.82",
+ "proc-macro2 1.0.83",
  "quote 1.0.36",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -2165,9 +2165,9 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
- "proc-macro2 1.0.82",
+ "proc-macro2 1.0.83",
  "quote 1.0.36",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -2287,9 +2287,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.82",
+ "proc-macro2 1.0.83",
  "quote 1.0.36",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -2440,9 +2440,9 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
- "proc-macro2 1.0.82",
+ "proc-macro2 1.0.83",
  "quote 1.0.36",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -2488,8 +2488,8 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
- "proc-macro2 1.0.82",
- "syn 2.0.64",
+ "proc-macro2 1.0.83",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -2509,9 +2509,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "0b33eb56c327dec362a9e55b3ad14f9d2f0904fb5a5b03b513ab5465399e9f43"
 dependencies = [
  "unicode-ident",
 ]
@@ -2532,7 +2532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8021cf59c8ec9c432cfc2526ac6b8aa508ecaf29cd415f271b8406c1b851c3fd"
 dependencies = [
  "quote 1.0.36",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -2565,7 +2565,7 @@ version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
- "proc-macro2 1.0.82",
+ "proc-macro2 1.0.83",
 ]
 
 [[package]]
@@ -2780,7 +2780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
- "crossbeam-utils 0.8.19",
+ "crossbeam-utils 0.8.20",
 ]
 
 [[package]]
@@ -3147,9 +3147,9 @@ version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
- "proc-macro2 1.0.82",
+ "proc-macro2 1.0.83",
  "quote 1.0.36",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -3326,7 +3326,7 @@ checksum = "70a2595fc3aa78f2d0e45dd425b22282dd863273761cc77780914b2cf3003acf"
 dependencies = [
  "cfg_aliases",
  "memchr",
- "proc-macro2 1.0.82",
+ "proc-macro2 1.0.83",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -3351,7 +3351,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
- "proc-macro2 1.0.82",
+ "proc-macro2 1.0.83",
  "quote 1.0.36",
  "serde",
  "serde_derive",
@@ -3365,7 +3365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
- "proc-macro2 1.0.82",
+ "proc-macro2 1.0.83",
  "quote 1.0.36",
  "serde",
  "serde_derive",
@@ -3409,18 +3409,18 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.82",
+ "proc-macro2 1.0.83",
  "quote 1.0.36",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.64"
+version = "2.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ad3dee41f36859875573074334c200d1add8e4a87bb37113ebd31d926b7b11f"
+checksum = "d2863d96a84c6439701d7a38f9de935ec562c8832cc55d1dde0f513b52fad106"
 dependencies = [
- "proc-macro2 1.0.82",
+ "proc-macro2 1.0.83",
  "quote 1.0.36",
  "unicode-ident",
 ]
@@ -3498,9 +3498,9 @@ version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
- "proc-macro2 1.0.82",
+ "proc-macro2 1.0.83",
  "quote 1.0.36",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -3566,7 +3566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.82",
+ "proc-macro2 1.0.83",
  "quote 1.0.36",
  "standback",
  "syn 1.0.109",
@@ -4016,9 +4016,9 @@ dependencies = [
  "bumpalo",
  "log 0.4.21",
  "once_cell",
- "proc-macro2 1.0.82",
+ "proc-macro2 1.0.83",
  "quote 1.0.36",
- "syn 2.0.64",
+ "syn 2.0.65",
  "wasm-bindgen-shared",
 ]
 
@@ -4050,9 +4050,9 @@ version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
- "proc-macro2 1.0.82",
+ "proc-macro2 1.0.83",
  "quote 1.0.36",
- "syn 2.0.64",
+ "syn 2.0.65",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4434,9 +4434,9 @@ version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
- "proc-macro2 1.0.82",
+ "proc-macro2 1.0.83",
  "quote 1.0.36",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
-flutter_rust_bridge = { version = "=2.0.0-dev.33", features = ["chrono"] }
-anyhow = "1.0.83"
+flutter_rust_bridge = { version = "=2.0.0-dev.34", features = ["chrono"] }
+anyhow = "1.0.86"
 derive_more = "0.99.17"
 atom_table = "1.1.0"
 ffsend-api = "0.7.3"

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -12,7 +12,9 @@
 #include <printing/printing_plugin.h>
 #include <screen_retriever/screen_retriever_plugin.h>
 #include <sentry_flutter/sentry_flutter_plugin.h>
+#include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <texture_rgba_renderer/texture_rgba_renderer_plugin_c_api.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 #include <window_manager/window_manager_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
@@ -28,8 +30,12 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("ScreenRetrieverPlugin"));
   SentryFlutterPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SentryFlutterPlugin"));
+  SharePlusWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
   TextureRgbaRendererPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("TextureRgbaRendererPluginCApi"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
   WindowManagerPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("WindowManagerPlugin"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -9,7 +9,9 @@ list(APPEND FLUTTER_PLUGIN_LIST
   printing
   screen_retriever
   sentry_flutter
+  share_plus
   texture_rgba_renderer
+  url_launcher_windows
   window_manager
 )
 


### PR DESCRIPTION
I had to replace `loggy` by `talker`, as `loggy` does not seem to be maintained anymore...

Also I has to workaround some `gen-l10n` issue (where Dart compiler suddenly can't find the virtual package `flutter_gen`).

Additionally `rps` is replaced by `just`. Just running `just` without arguments should do the same as `rps` without arguments did before.