### PR TITLE
Template debug middleground toggle and image cache for manual collage screen

### DIFF
--- a/lib/views/custom_widgets/photo_collage.dart
+++ b/lib/views/custom_widgets/photo_collage.dart
@@ -49,6 +49,7 @@ class PhotoCollage extends StatefulWidget {
   final double padding;
   final bool showLogo;
   final bool showBackground;
+  final bool showMiddleground;
   final bool showForeground;
   final bool singleMode;
   final int? debug;
@@ -62,6 +63,7 @@ class PhotoCollage extends StatefulWidget {
     this.showLogo = false,
     this.singleMode = false,
     this.showBackground = true,
+    this.showMiddleground = true,
     this.showForeground = true,
     this.debug,
     this.decodeCallback,
@@ -177,7 +179,7 @@ class PhotoCollageState extends State<PhotoCollage> with Logger {
               child: ImageWithLoaderFallback.file(templates[TemplateKind.back]?[i], fit: BoxFit.cover),
             ),
         ],
-        if (widget.debug == null)
+        if (widget.showMiddleground)
           Padding(
             padding: EdgeInsets.all(gap + widget.padding),
             child: _getInnerLayout(localizations),
@@ -187,13 +189,12 @@ class PhotoCollageState extends State<PhotoCollage> with Logger {
             decoration: BoxDecoration(
               border: Border.all(width: widget.padding, color: const ui.Color.fromARGB(126, 212, 53, 53)),
             ),
-            child: DecoratedBox(
-              decoration: BoxDecoration(
-                border: Border.all(width: gap, color: const ui.Color.fromARGB(127, 255, 255, 255)),
-              ),
-              child: Padding(
-                padding: EdgeInsets.all(gap + widget.padding),
-                child: _getInnerLayout(localizations),
+            child: Padding(
+              padding: EdgeInsets.all(widget.padding),
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  border: Border.all(width: gap, color: const ui.Color.fromARGB(127, 255, 255, 255)),
+                ),
               ),
             ),
           ),

--- a/lib/views/manual_collage_screen/manual_collage_screen_view.dart
+++ b/lib/views/manual_collage_screen/manual_collage_screen_view.dart
@@ -42,7 +42,7 @@ class ManualCollageScreenView extends ScreenViewBase<ManualCollageScreenViewMode
         clipBehavior: Clip.none,
         children: [
           Center(
-            child: ImageWithLoaderFallback.file(image.file, fit: BoxFit.contain),
+            child: ImageWithLoaderFallback.file(image.file, fit: BoxFit.contain, cacheWidth: 256,),
           ),
           AnimatedOpacity(
             opacity: image.isSelected ? 1 : 0,

--- a/lib/views/settings_screen/settings_screen_view.templating.dart
+++ b/lib/views/settings_screen/settings_screen_view.templating.dart
@@ -38,6 +38,14 @@ Widget _getTemplatingSettings(SettingsScreenViewModel viewModel, SettingsScreenC
               buttonMargin,
               Observer(builder: (context) =>
                 ToggleSwitch(
+                  checked: viewModel.previewTemplateShowMiddle,
+                  onChanged: (v) => viewModel.previewTemplateShowMiddle = v,
+                  content: const Text("Show middleground"),
+                )
+              ),
+              buttonMargin,
+              Observer(builder: (context) =>
+                ToggleSwitch(
                   checked: viewModel.previewTemplateShowFront,
                   onChanged: (v) => viewModel.previewTemplateShowFront = v,
                   content: const Text("Show foreground"),
@@ -82,6 +90,7 @@ Widget _getTemplateExampleRow(SettingsScreenViewModel viewModel, SettingsScreenC
               aspectRatio: 1/viewModel.collageAspectRatioSetting,
               padding: viewModel.collagePaddingSetting,
               showBackground: viewModel.previewTemplateShowBack,
+              showMiddleground: viewModel.previewTemplateShowMiddle,
               showForeground: viewModel.previewTemplateShowFront,
             ),
           ),

--- a/lib/views/settings_screen/settings_screen_view_model.dart
+++ b/lib/views/settings_screen/settings_screen_view_model.dart
@@ -30,6 +30,8 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
   @observable
   bool previewTemplateShowFront = true;
   @observable
+  bool previewTemplateShowMiddle = true;
+  @observable
   bool previewTemplateShowBack = true;
   String get selectedBackTemplate => collageKey.currentState?.templates[TemplateKind.back]![previewTemplate]?.path ?? "-";
   String get selectedFrontTemplate => collageKey.currentState?.templates[TemplateKind.front]![previewTemplate]?.path ?? "-";


### PR DESCRIPTION
Mostly what the title says.
The middleground (photo layer) can now be toggled off in the template debug screen for easier creation or debugging of templates.
`cacheWidth` has been added to the images in the manual collage screen to make it faster.