### PR TITLE
Improve logging

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:momento_booth/repositories/secret/secret_repository.dart';
 import 'package:momento_booth/repositories/secret/secure_storage_secret_repository.dart';
 import 'package:momento_booth/src/rust/frb_generated.dart';
 import 'package:momento_booth/utils/environment_variables.dart';
+import 'package:momento_booth/utils/file_utils.dart';
 import 'package:momento_booth/utils/platform_and_app.dart';
 import 'package:path/path.dart' as path;
 import 'package:sentry_flutter/sentry_flutter.dart';
@@ -39,6 +40,8 @@ void main() async {
   NotificationsManager.instance.initialize();
   PrintingManager.instance.initialize();
 
+  await _createPathsSafe();
+
   String sentryDsn = await _resolveSentryDsnOverride() ?? const String.fromEnvironment("SENTRY_DSN", defaultValue: '');
   await SentryFlutter.init(
     (options) {
@@ -65,6 +68,19 @@ void _ensureGPhoto2EnvironmentVariables() {
   // but it does makes libgphoto2 resolve them correctly through its call to `getenv`.
   putenv("IOLIBS", iolibsDefine);
   putenv("CAMLIBS", camlibsDefine);
+}
+
+Future<void> _createPathsSafe() async {
+  List<String> paths = [
+    SettingsManager.instance.settings.templatesFolder,
+    SettingsManager.instance.settings.output.localFolder,
+    SettingsManager.instance.settings.hardware.captureLocation,
+    SettingsManager.instance.settings.hardware.captureStorageLocation,
+  ];
+
+  for (String path in paths) {
+    await createPathSafe(path);
+  }
 }
 
 Future<String?> _resolveSentryDsnOverride() async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -79,7 +79,7 @@ Future<void> _createPathsSafe() async {
   ];
 
   for (String path in paths) {
-    await createPathSafe(path);
+    createPathSafe(path);
   }
 }
 

--- a/lib/managers/live_view_manager.dart
+++ b/lib/managers/live_view_manager.dart
@@ -106,7 +106,7 @@ abstract class _LiveViewManagerBase with Store {
       _currentGPhoto2CameraId = gPhoto2CameraIdSetting;
 
       // GPhoto2
-      if (_gPhoto2Camera != null && _gPhoto2Camera!.isOpened) {
+      if (_gPhoto2Camera != null) {
         await _gPhoto2Camera!.dispose();
         _gPhoto2Camera = null;
       }

--- a/lib/utils/file_utils.dart
+++ b/lib/utils/file_utils.dart
@@ -2,6 +2,9 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:momento_booth/main.dart';
+import 'package:talker/talker.dart';
+
 Future<File> writeBytesToFileLocked(String path, Uint8List data) async {
   File file = File(path);
   RandomAccessFile raFile = await file.open(mode: FileMode.writeOnly);
@@ -19,4 +22,12 @@ Future<File> writeBytesToFileLocked(String path, Uint8List data) async {
 Future<File> writeStringFileLocked(String path, String data) {
   Uint8List bytes = const Utf8Encoder().convert(data);
   return writeBytesToFileLocked(path, bytes);
+}
+
+Future<void> createPathSafe(String path) async {
+  try {
+    await Directory(path).create(recursive: true);
+  } catch (s) {
+    getIt<Talker>().warning("Could not create path [$path]: $s");
+  }
 }

--- a/lib/utils/file_utils.dart
+++ b/lib/utils/file_utils.dart
@@ -24,9 +24,13 @@ Future<File> writeStringFileLocked(String path, String data) {
   return writeBytesToFileLocked(path, bytes);
 }
 
-Future<void> createPathSafe(String path) async {
+void createPathSafe(String path) {
   try {
-    await Directory(path).create(recursive: true);
+    Directory directory = Directory(path);
+    if (!directory.existsSync()) {
+      directory.createSync(recursive: true);
+      getIt<Talker>().info("Created path [$path]");
+    }
   } catch (s) {
     getIt<Talker>().warning("Could not create path [$path]: $s");
   }

--- a/lib/utils/hardware.dart
+++ b/lib/utils/hardware.dart
@@ -13,6 +13,7 @@ import 'package:momento_booth/utils/logger.dart';
 import 'package:path/path.dart' as path;
 import 'package:pdf/pdf.dart';
 import 'package:pdf/widgets.dart' as pw;
+import 'package:talker_flutter/talker_flutter.dart';
 import 'package:win32/win32.dart';
 
 PdfPageFormat getNormalPageSize() {
@@ -245,7 +246,7 @@ List<PrinterStatus> checkPrintersStatus(List<String> printerNames) {
       // If the function fails, then at least we can say there is _some_ error
       hasError = true;
       jobList = [];
-      getIt<Logger>().logError(e);
+      getIt<Talker>().error('Could not get joblist', e);
     }
     // Check if there are prints that have errored
     hasError = hasError || jobList.fold(false, (previousValue, element) => previousValue || element.status.contains(JobStatus.error));
@@ -285,7 +286,7 @@ List<JobInfo> getJobList(String printerName) {
     final bool enumSuccess = EnumJobs(printerHandleValue, 0, 100, returnType, jobs, numBytes, usedBytes, numJobs) != 0;
     if (!enumSuccess) throw Win32Exception.fromLastError("Error enumerating print jobs for printer $printerName");
 
-    getIt<Logger>().logDebug("Printer $printerName (handle ${printerHandleValue.toHexString(32)}) has ${numJobs.value} jobs (object is ${usedBytes.value} bytes)");
+    getIt<Talker>().debug("Printer $printerName (handle ${printerHandleValue.toHexString(32)}) has ${numJobs.value} jobs (object is ${usedBytes.value} bytes)");
 
     List<JobInfo> jobList = [];
     for (var i = 0; i < numJobs.value; i++) {
@@ -294,7 +295,7 @@ List<JobInfo> getJobList(String printerName) {
       var statusVal = job.Status;
       var statusString = job.pStatus.address != 0 ? job.pStatus.toDartString() : "";
       if (statusString.isNotEmpty) {
-        getIt<Logger>().logDebug("Custom statusstring for printer $printerName: $statusString");
+        getIt<Talker>().debug("Custom statusstring for printer $printerName: $statusString");
       }
       // Extract list of statusses
       final List<JobStatus> status = JobStatus.values.where((element) => element.value & statusVal > 0).toList();

--- a/lib/utils/hardware.dart
+++ b/lib/utils/hardware.dart
@@ -9,7 +9,6 @@ import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/utils/file_utils.dart';
-import 'package:momento_booth/utils/logger.dart';
 import 'package:path/path.dart' as path;
 import 'package:pdf/pdf.dart';
 import 'package:pdf/widgets.dart' as pw;

--- a/lib/views/settings_screen/settings_screen_controller.dart
+++ b/lib/views/settings_screen/settings_screen_controller.dart
@@ -6,6 +6,7 @@ import 'package:momento_booth/managers/sfx_manager.dart';
 import 'package:momento_booth/models/maker_note_data.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/src/rust/utils/ipp_client.dart';
+import 'package:momento_booth/utils/file_utils.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
 import 'package:momento_booth/views/settings_screen/settings_screen_view_model.dart';
 
@@ -122,6 +123,7 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
   void onTemplatesFolderChanged(String? templatesFolder) {
     if (templatesFolder != null) {
       viewModel.updateSettings((settings) => settings.copyWith(templatesFolder: templatesFolder));
+      createPathSafe(templatesFolder);
     }
   }
 
@@ -212,6 +214,7 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
   void onCaptureLocationChanged(String? captureLocation) {
     if (captureLocation != null) {
       viewModel.updateSettings((settings) => settings.copyWith.hardware(captureLocation: captureLocation));
+      createPathSafe(captureLocation);
     }
   }
 
@@ -224,6 +227,7 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
   void onCaptureStorageLocationChanged(String? captureStorageLocation) {
     if (captureStorageLocation != null) {
       viewModel.updateSettings((settings) => settings.copyWith.hardware(captureStorageLocation: captureStorageLocation));
+      createPathSafe(captureStorageLocation);
     }
   }
 
@@ -406,6 +410,7 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
   void onLocalFolderChanged(String? localFolder) {
     if (localFolder != null) {
       viewModel.updateSettings((settings) => settings.copyWith.output(localFolder: localFolder));
+      createPathSafe(localFolder);
     }
   }
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1030,6 +1030,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "flutter_logger"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3d407fd7ed76065e3d7ddbc574af50082d4301dcbf19000badc3c4367fdbd0"
+dependencies = [
+ "log 0.4.22",
+ "once_cell",
+]
+
+[[package]]
 name = "flutter_rust_bridge"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2978,6 +2988,7 @@ dependencies = [
  "dashmap 6.0.1",
  "dlopen",
  "ffsend-api",
+ "flutter_logger",
  "flutter_rust_bridge",
  "gphoto2",
  "image 0.25.2",
@@ -2985,6 +2996,7 @@ dependencies = [
  "ipp",
  "jpeg-encoder",
  "little_exif",
+ "log 0.4.22",
  "noise",
  "nokhwa",
  "num",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -34,6 +34,8 @@ num-traits = "0.2.19"
 num-derive = "0.4.2"
 rexiv2 = { version = "0.10.0", features = ["raw-tag-access"] }
 regex = "1.10.6"
+log = "0.4.22"
+flutter_logger = "0.6.1"
 nokhwa = { git = "https://github.com/l1npengtul/nokhwa.git", rev = "74a98ace10368320cfcc2186118ae10d5308ca59", default-features = true, features = ["input-native", "output-threaded", "flume"] }
 
 [patch.crates-io]

--- a/rust/src/api/noise.rs
+++ b/rust/src/api/noise.rs
@@ -5,8 +5,9 @@ use dashmap::DashMap;
 pub use ipp::model::PrinterState;
 pub use ipp::model::JobState;
 use turborand::rng::Rng;
+use log::debug;
 
-use crate::{hardware_control::live_view::white_noise::{self, WhiteNoiseGeneratorHandle}, helpers::log_debug, models::images::RawImage, utils::flutter_texture::FlutterTexture};
+use crate::{hardware_control::live_view::white_noise::{self, WhiteNoiseGeneratorHandle}, models::images::RawImage, utils::flutter_texture::FlutterTexture};
 
 pub static NOISE_HANDLES: LazyLock<DashMap<u32, WhiteNoiseGeneratorHandle>> = LazyLock::new(|| DashMap::<u32, WhiteNoiseGeneratorHandle>::new());
 
@@ -37,7 +38,7 @@ pub fn noise_close(handle_id: u32) {
     // Retrieve handle
     let handle = NOISE_HANDLES.remove(&handle_id).expect("Invalid noise handle ID");
 
-    log_debug("Stopping white noise generator with handle ".to_string() + &handle_id.to_string());
+    debug!("Stopping white noise generator with handle {}", &handle_id);
     handle.1.stop();
-    log_debug("Stopped white noise generator with handle ".to_string() + &handle_id.to_string());
+    debug!("Stopped white noise generator with handle {}", &handle_id);
 }

--- a/rust/src/helpers.rs
+++ b/rust/src/helpers.rs
@@ -1,25 +1,18 @@
-use std::sync::{RwLock, OnceLock};
+use std::sync::OnceLock;
 
 use crate::hardware_control::live_view::nokhwa;
 use pathsep::{path_separator, join_path};
 use tokio::runtime::{self, Runtime};
 use crate::{frb_generated::StreamSink, hardware_control::live_view::gphoto2};
+use log::debug;
 
-const TARGET: &str = include_str!(join_path!(env!("OUT_DIR"), "target_name.txt"));
-
-static LOG_STREAM: RwLock<Option<StreamSink<LogEvent>>> = RwLock::new(None);
+pub const TARGET: &str = include_str!(join_path!(env!("OUT_DIR"), "target_name.txt"));
 
 pub static TOKIO_RUNTIME: OnceLock<Runtime> = OnceLock::new();
 
-pub fn initialize_log(log_sink: StreamSink<LogEvent>) {
-    let log_write = LOG_STREAM.write();
-    *log_write.expect("Err") = Some(log_sink);
-
-    log_debug("Native library compiled with target ".to_string() + TARGET)
-}
-
 pub fn initialize_hardware(ready_sink: StreamSink<HardwareInitializationFinishedEvent>) {
-    log_debug("initialize_hardware() started".to_string());
+    debug!("Compiled for target {}", TARGET);
+    debug!("{}", "initialize_hardware() started");
 
     // Tokio runtime
     TOKIO_RUNTIME.get_or_init(|| runtime::Builder::new_multi_thread().enable_all().build().unwrap());
@@ -34,7 +27,7 @@ pub fn initialize_hardware(ready_sink: StreamSink<HardwareInitializationFinished
 
     // Nokhwa initialize
     nokhwa::initialize(move |success| {
-        log_debug("initialize_hardware() nokhwa init result: ".to_string() + &success.to_string());
+        debug!("initialize_hardware() nokhwa init result: {}", &success);
         ready_sink.add(HardwareInitializationFinishedEvent {
             step: HardwareInitializationStep::Nokhwa,
             has_succeeded: success,
@@ -42,53 +35,12 @@ pub fn initialize_hardware(ready_sink: StreamSink<HardwareInitializationFinished
         });
     });
 
-    log_debug("initialize_hardware() ended".to_string());
+    debug!("{}", "initialize_hardware() ended");
 }
-
-pub fn log_event(event: LogEvent) {
-    let read_guard = LOG_STREAM.read().expect("Could not acquire read lock");
-    let log_sink = read_guard.as_ref().expect("Expected log stream to be initialized");
-    log_sink.add(event);
-}
-
-// /////// //
-// Helpers //
-// /////// //
-
-pub fn log_debug(message: String) {
-    log_event(LogEvent { message, level: LogLevel::Debug })
-}
-
-pub fn log_info(message: String) {
-    log_event(LogEvent { message, level: LogLevel::Info })
-}
-
-pub fn log_warning(message: String) {
-    log_event(LogEvent { message, level: LogLevel::Warning })
-}
-
-pub fn log_error(message: String) {
-    log_event(LogEvent { message, level: LogLevel::Error })
-}
-
 
 // /////// //
 // Structs //
 // /////// //
-
-#[derive(Debug, Clone)]
-pub struct LogEvent {
-    pub message: String,
-    pub level: LogLevel,
-}
-
-#[derive(Debug, Clone)]
-pub enum LogLevel {
-    Debug,
-    Info,
-    Warning,
-    Error,
-}
 
 #[derive(Debug, Clone)]
 pub struct HardwareInitializationFinishedEvent {

--- a/rust/src/utils/flutter_texture.rs
+++ b/rust/src/utils/flutter_texture.rs
@@ -1,10 +1,8 @@
 use std::ffi::{c_int, c_void};
-
 use dlopen::{symbor::{Library, Symbol}, Error as LibError};
-
-use crate::{helpers::log_error, models::images::RawImage};
-
+use crate::models::images::RawImage;
 use std::sync::LazyLock;
+use log::error;
 
 #[cfg(all(target_os = "windows"))]
 pub static TEXTURE_RGBA_RENDERER_PLUGIN: LazyLock<Result<Library, LibError>> = LazyLock::new(|| Library::open("texture_rgba_renderer_plugin.dll"));
@@ -42,13 +40,13 @@ impl FlutterTexture {
                 match find_sym_res {
                     Ok(sym) => Some(sym),
                     Err(error) => {
-                        log_error("Failed to find symbol FlutterRgbaRendererPluginOnRgba: ".to_string() + &error.to_string());
+                        error!("Failed to find symbol FlutterRgbaRendererPluginOnRgba: {}", &error);
                         None
                     }
                 }
             }
             Err(error) => {
-                log_error("Failed to load texture rgba renderer plugin: ".to_string() + &error.to_string());
+                error!("Failed to load texture rgba renderer plugin: {}", &error);
                 None
             }
         };


### PR DESCRIPTION
This PR:
- Fixes an issue where printer status detection could not log
- Fixes errors in the camera status check that occurred when the camera wasn't opened yet
- Creates any file system paths used by the application in order to fix errors due to non existing directories
- Removes custom Rust-to-Dart log tunneling method in favor of `flutter_logger`, any gPhoto2 log messages should now appear in the application log found in the Settings screen