### PR TITLE
Add PR CI script to build libgphoto2 from git

### DIFF
--- a/.github/workflows/pr-ci-app-win-x64-libgphoto2-from-git.yml
+++ b/.github/workflows/pr-ci-app-win-x64-libgphoto2-from-git.yml
@@ -1,0 +1,166 @@
+name: PR CI App - Windows x64 (libgphoto2 from git)
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths-ignore: [ documentation/**, .github/workflows/pr-ci-documentation.yml, .github/workflows/deploy-documentation.yml, README.md ]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  build:
+    if: ${{ startsWith(github.event.pull_request.head.ref, 'release/') != true && github.event.pull_request.draft != true }}
+
+    runs-on: windows-latest
+    
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Detect Flutter Version
+      uses: kuhnroyal/flutter-fvm-config-action@v2
+
+    - name: Setup Flutter
+      uses: hrishikesh-kadam/setup-flutter@v1
+      with:
+        ref: ${{ env.FLUTTER_VERSION }}
+        setFlutterRootPath: 'true'
+        addPubCacheBinToPath: 'true'
+        flutterPrecache: '--windows'
+
+    - name: Setup MSYS2
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: clang64
+        path-type: inherit
+        pacboy: pkgconf:c gexiv2:c curl-winssl:c nghttp2:c nghttp3:c libusb:c gcc:c
+        install: git patch
+
+    - name: Build libgphoto2 from master
+      shell: msys2 {0}
+      env:
+        MSYS2_PATH_TYPE: minimal
+      run: |
+        git clone https://github.com/momentobooth/MINGW-packages
+        cd MINGW-packages/mingw-w64-libgphoto2
+        makepkg -s --noconfirm
+        pacman -U mingw-w64-clang-x86_64-libgphoto2-*-any.pkg.tar.zst --noconfirm
+
+    - name: Workaround MSVC compiler looking for .lib files
+      shell: pwsh
+      run: |
+        cd $(msys2 -c 'cygpath -w /clang64/lib')
+        cp libgexiv2.dll.a gexiv2.lib
+        cp libgio-2.0.dll.a gio-2.0.lib
+        cp libglib-2.0.dll.a glib-2.0.lib
+        cp libgobject-2.0.dll.a gobject-2.0.lib
+        cp libgphoto2.dll.a gphoto2.lib
+        cp libgphoto2_port.dll.a gphoto2_port.lib
+        cp libintl.dll.a intl.lib
+
+    - name: Fix environment for build and bundle
+      run: |
+        Add-Content $env:GITHUB_PATH (msys2 -c 'cygpath -w /clang64/bin')
+        echo "MINGW_BUNDLEDLLS_SEARCH_PATH=$(msys2 -c 'cygpath -w /clang64/bin')" >> $env:GITHUB_ENV
+        echo "CLANG64_LIB_PATH=$(msys2 -c 'cygpath -w /clang64/lib')" >> $env:GITHUB_ENV
+
+    - name: Install minimal Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+        target: x86_64-pc-windows-msvc
+
+    - name: Setup Rust compiled code cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: |
+          rust -> ../build/windows/x64/plugins/rust_lib_momento_booth/cargokit_build
+          rust -> target
+
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@v0.0.5
+
+    - name: Install cargo-expand
+      uses: baptiste0928/cargo-install@v3
+      with:
+        crate: cargo-expand
+
+    - name: Install flutter_rust_bridge_codegen
+      uses: baptiste0928/cargo-install@v3
+      with:
+        crate: flutter_rust_bridge_codegen
+        version: "2.2.0"
+
+    - name: Install Dependencies
+      run: flutter pub get --enforce-lockfile
+
+    - name: Generate localizations
+      run: flutter gen-l10n
+
+    - name: Generate Dart/Rust bridging code
+      run: flutter_rust_bridge_codegen generate
+
+    - name: Run build_runner code generation
+      run: dart run build_runner build --delete-conflicting-outputs
+      
+    - name: Flutter analyze
+      run: flutter analyze
+
+    - name: Build project
+      run: flutter build windows -v --release --dart-define SENTRY_DSN=${{ secrets.SENTRY_DSN }} --dart-define SENTRY_ENVIRONMENT=Production --dart-define SENTRY_RELEASE=${{ github.sha }} --dart-define IOLIBS=libgphoto2_iolibs --dart-define CAMLIBS=libgphoto2_camlibs
+
+    - name: Workaround bundle script not working
+      shell: msys2 {0}
+      env:
+        MSYS2_PATH_TYPE: minimal
+      run: |
+        pacboy -Rc llvm --noconfirm
+
+    - name: Bundle dependencies
+      shell: pwsh
+      run: |
+        $bundle_script = curl https://raw.githubusercontent.com/momentobooth/mingw-bundledlls/master/mingw-bundledlls
+        echo $bundle_script | python - --copy build\windows\x64\runner\Release\rust_lib_momento_booth.dll
+
+        # Bundle iolibs and camlibs
+        mkdir build\windows\x64\runner\Release\libgphoto2_iolibs
+        cp $Env:CLANG64_LIB_PATH\libgphoto2_port\*\*.dll build\windows\x64\runner\Release\libgphoto2_iolibs
+        mkdir build\windows\x64\runner\Release\libgphoto2_camlibs
+        cp $Env:CLANG64_LIB_PATH\libgphoto2\*\*.dll build\windows\x64\runner\Release\libgphoto2_camlibs
+
+        # Bundle dependency libs
+        cd build\windows\x64\runner\Release\
+        $lib_folders = @('libgphoto2_iolibs', 'libgphoto2_camlibs')
+        foreach ( $folder in $lib_folders )
+        {
+          $libs = ls $folder
+          foreach ( $lib in $libs )
+          {
+            echo $bundle_script | python - --copy $lib.fullName
+          }
+
+          # Now move all libraries to the same folder as the executable (except iolibs and camlibs themselves)
+          $files = ls $folder
+          foreach ( $file in $files )
+          {
+            if ($libs.Name -notcontains $file.Name) {
+              Move-Item -Path $file -Destination $file.Directory.Parent.FullName -force
+            }
+          }
+        }
+
+    - name: Archive Release
+      uses: thedoctor0/zip-release@0.7.6
+      with:
+        type: zip
+        directory: build/windows/x64/runner/Release
+        filename: MomentoBooth-Win-x64.zip
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: Windows x64
+        path: build/windows/x64/runner/Release/MomentoBooth-Win-x64.zip


### PR DESCRIPTION
This PR adds a hacked together variant of the Windows PR CI pipeline script, that builds libgphoto2 from the latest git master instead of using the MSYS2/Clang64 package. This allows for testing whether a future libgphoto2 version will fix a certain issue and if it's still compatible with the Rust wrapper and MomentoBooth.