### PR TITLE
Allow overriding the default 'Touch to Start' text

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,20 +5,20 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "momento-booth",
+            "name": "MomentoBooth",
             "request": "launch",
             "type": "dart",
             "program": "lib/main.dart"
         },
         {
-            "name": "momento-booth (profile mode)",
+            "name": "MomentoBooth (profile mode)",
             "request": "launch",
             "type": "dart",
             "flutterMode": "profile",
             "program": "lib/main.dart"
         },
         {
-            "name": "momento-booth (release mode)",
+            "name": "MomentoBooth (release mode)",
             "request": "launch",
             "type": "dart",
             "flutterMode": "release",

--- a/lib/extensions/string_extension.dart
+++ b/lib/extensions/string_extension.dart
@@ -1,0 +1,5 @@
+extension StringExtension on String? {
+
+  String? get nullIfEmpty => (this == null || this!.isEmpty) ? null : this;
+
+}

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -24,7 +24,7 @@ part 'settings.g.dart';
 
 @Freezed(fromJson: true, toJson: true)
 class Settings with _$Settings implements TomlEncodableValue {
-  
+
   const Settings._();
 
   const factory Settings({
@@ -44,7 +44,7 @@ class Settings with _$Settings implements TomlEncodableValue {
   factory Settings.withDefaults() => Settings.fromJson({});
 
   factory Settings.fromJson(Map<String, Object?> json) => _$SettingsFromJson(json);
-  
+
   @override
   Map<String, dynamic> toTomlValue() => toJson();
 
@@ -98,7 +98,7 @@ class HardwareSettings with _$HardwareSettings implements TomlEncodableValue {
   factory HardwareSettings.withDefaults() => HardwareSettings.fromJson({});
 
   factory HardwareSettings.fromJson(Map<String, Object?> json) => _$HardwareSettingsFromJson(json);
-  
+
   @override
   Map<String, dynamic> toTomlValue() => toJson();
 
@@ -110,7 +110,7 @@ class PrintLayoutSettings with _$PrintLayoutSettings implements TomlEncodableVal
   const PrintLayoutSettings._();
 
   const factory PrintLayoutSettings({
-    
+
     @JsonKey(defaultValue: MediaSettings.withDefaults) required MediaSettings mediaSizeNormal,
     @JsonKey(defaultValue: MediaSettings.withDefaults) required MediaSettings mediaSizeSplit,
     @JsonKey(defaultValue: MediaSettings.withDefaults) required MediaSettings mediaSizeSmall,
@@ -122,7 +122,7 @@ class PrintLayoutSettings with _$PrintLayoutSettings implements TomlEncodableVal
   factory PrintLayoutSettings.withDefaults() => PrintLayoutSettings.fromJson({});
 
   factory PrintLayoutSettings.fromJson(Map<String, Object?> json) => _$PrintLayoutSettingsFromJson(json);
-  
+
   @override
   Map<String, dynamic> toTomlValue() => toJson();
 
@@ -142,7 +142,7 @@ class MediaSettings with _$MediaSettings implements TomlEncodableValue {
   factory MediaSettings.withDefaults() => MediaSettings.fromJson({});
 
   factory MediaSettings.fromJson(Map<String, Object?> json) => _$MediaSettingsFromJson(json);
-  
+
   @override
   Map<String, dynamic> toTomlValue() => toJson();
 
@@ -162,7 +162,7 @@ class GridSettings with _$GridSettings implements TomlEncodableValue {
   factory GridSettings.withDefaults() => GridSettings.fromJson({});
 
   factory GridSettings.fromJson(Map<String, Object?> json) => _$GridSettingsFromJson(json);
-  
+
   @override
   Map<String, dynamic> toTomlValue() => toJson();
 
@@ -218,6 +218,7 @@ class UiSettings with _$UiSettings implements TomlEncodableValue {
     @Default(45) int returnToHomeTimeoutSeconds,
     @Default(Language.english) Language language,
     @Default([]) List<LottieAnimationSettings> introScreenLottieAnimations,
+    @Default("") String introScreenTouchToStartOverrideText,
     @Default(true) bool displayConfetti,
     @Default(false) bool customColorConfetti,
     @Default(false) bool enableSfx,

--- a/lib/views/settings_screen/settings_screen_controller.dart
+++ b/lib/views/settings_screen/settings_screen_controller.dart
@@ -35,6 +35,9 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
   TextEditingController? _firefoxSendServerUrlController;
   TextEditingController get firefoxSendServerUrlController => _firefoxSendServerUrlController ??= TextEditingController(text: viewModel.firefoxSendServerUrlSetting);
 
+  TextEditingController? _introScreenTouchToStartOverrideTextController;
+  TextEditingController get introScreenTouchToStartOverrideTextController => _introScreenTouchToStartOverrideTextController ??= TextEditingController(text: viewModel.introScreenTouchToStartOverrideTextSetting);
+
   TextEditingController? _gPhoto2CaptureTargetController;
   TextEditingController get gPhoto2CaptureTargetController => _gPhoto2CaptureTargetController ??= TextEditingController(text: viewModel.gPhoto2CaptureTargetSetting);
 
@@ -447,6 +450,12 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
   void onReturnToHomeTimeoutSecondsChanged(int? returnToHomeTimeoutSeconds) {
     if (returnToHomeTimeoutSeconds != null) {
       viewModel.updateSettings((settings) => settings.copyWith.ui(returnToHomeTimeoutSeconds: returnToHomeTimeoutSeconds));
+    }
+  }
+
+  void onIntroScreenTouchToStartOverrideText(String? introScreenTouchToStartOverrideText) {
+    if (introScreenTouchToStartOverrideText != null) {
+      viewModel.updateSettings((settings) => settings.copyWith.ui(introScreenTouchToStartOverrideText: introScreenTouchToStartOverrideText));
     }
   }
 

--- a/lib/views/settings_screen/settings_screen_view.ui.dart
+++ b/lib/views/settings_screen/settings_screen_view.ui.dart
@@ -11,6 +11,13 @@ Widget _getUiSettings(SettingsScreenViewModel viewModel, SettingsScreenControlle
         value: () => viewModel.primaryColorSetting,
         onChanged: controller.onPrimaryColorChanged,
       ),
+      TextInputCard(
+        icon: LucideIcons.heading,
+        title: "Alternative 'Touch to start' title text",
+        subtitle: "The override text that will be shown on the Start screen instead of 'Touch to start'. Leave empty to show the default text from the translations data.",
+        controller: controller.introScreenTouchToStartOverrideTextController,
+        onFinishedEditing: controller.onIntroScreenTouchToStartOverrideText,
+      ),
       NumberInputCard(
         icon: LucideIcons.timer,
         title: "Return to home timeout",

--- a/lib/views/settings_screen/settings_screen_view_model.dart
+++ b/lib/views/settings_screen/settings_screen_view_model.dart
@@ -192,6 +192,7 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
   double get resolutionMultiplier => SettingsManager.instance.settings.output.resolutionMultiplier;
   Color get primaryColorSetting => SettingsManager.instance.settings.ui.primaryColor;
   int get returnToHomeTimeoutSeconds => SettingsManager.instance.settings.ui.returnToHomeTimeoutSeconds;
+  String get introScreenTouchToStartOverrideTextSetting => SettingsManager.instance.settings.ui.introScreenTouchToStartOverrideText;
   bool get displayConfettiSetting => SettingsManager.instance.settings.ui.displayConfetti;
   bool get customColorConfettiSetting => SettingsManager.instance.settings.ui.customColorConfetti;
   bool get enableSfxSetting => SettingsManager.instance.settings.ui.enableSfx;

--- a/lib/views/start_screen/start_screen_view.dart
+++ b/lib/views/start_screen/start_screen_view.dart
@@ -69,8 +69,9 @@ class StartScreenView extends ScreenViewBase<StartScreenViewModel, StartScreenCo
           flex: 2,
           child: Center(
             child: AutoSizeText(
-              localizations.startScreenTouchToStartButton,
+              viewModel.touchToStartText,
               style: theme.titleStyle,
+              textAlign: TextAlign.center,
             ),
           ),
         ),

--- a/lib/views/start_screen/start_screen_view_model.dart
+++ b/lib/views/start_screen/start_screen_view_model.dart
@@ -1,4 +1,5 @@
 import 'package:mobx/mobx.dart';
+import 'package:momento_booth/extensions/string_extension.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/models/settings.dart';
@@ -12,6 +13,11 @@ abstract class StartScreenViewModelBase extends ScreenViewModelBase with Store {
 
   @computed
   List<LottieAnimationSettings> get introScreenLottieAnimations => SettingsManager.instance.settings.ui.introScreenLottieAnimations;
+
+  @computed
+  String get touchToStartText =>
+      SettingsManager.instance.settings.ui.introScreenTouchToStartOverrideText.nullIfEmpty ??
+      localizations.startScreenTouchToStartButton;
 
   @observable
   bool isBusy = false;


### PR DESCRIPTION
If you set this to a custom text ...

![Z_x-0wCk](https://github.com/user-attachments/assets/749490c5-cb97-4479-a25c-371a9fe90762)

the start screen will now look like this:

![DBw3tMUe](https://github.com/user-attachments/assets/b4f7963c-47c6-438c-aa00-cc92173a9296)

A long text just to show what happens:

![FJ0uCaD4](https://github.com/user-attachments/assets/61ee6c42-d424-4953-b77e-cc74c2a9e0f9)


