### PR TITLE
Update dependencies, have GH Actions automatically update macOS build files when necessary

### DIFF
--- a/.github/workflows/pr-ci-app-macos-arm64.yml
+++ b/.github/workflows/pr-ci-app-macos-arm64.yml
@@ -116,5 +116,4 @@ jobs:
       uses: EndBug/add-and-commit@v9
       with:
         add: macos
-        default_author: github_actions
         message: 'Update macOS build files'

--- a/.github/workflows/pr-ci-app-macos-arm64.yml
+++ b/.github/workflows/pr-ci-app-macos-arm64.yml
@@ -12,6 +12,9 @@ concurrency:
 
 jobs:
   build:
+    permissions:
+      contents: write
+
     if: ${{ startsWith(github.event.pull_request.head.ref, 'release/') != true && github.event.pull_request.draft != true }}
 
     runs-on: macos-latest
@@ -24,6 +27,9 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Install build dependencies
       run: brew install ruby libgphoto2 gexiv2
@@ -102,4 +108,13 @@ jobs:
       run: flutter analyze
 
     - name: Build project
-      run: FLUTTER_XCODE_ARCHS=arm64 flutter build macos -v --dart-define SENTRY_DSN=${{ secrets.SENTRY_DSN }} --dart-define SENTRY_ENVIRONMENT=Production --dart-define SENTRY_RELEASE=${{ steps.extract_release_version.outputs.distributor_version }} --dart-define FLUTTER_VERSION=${{ env.FLUTTER_VERSION }}
+      run: |
+        rm macos/Podfile.lock
+        FLUTTER_XCODE_ARCHS=arm64 flutter build macos -v --dart-define SENTRY_DSN=${{ secrets.SENTRY_DSN }} --dart-define SENTRY_ENVIRONMENT=Production --dart-define SENTRY_RELEASE=${{ steps.extract_release_version.outputs.distributor_version }} --dart-define FLUTTER_VERSION=${{ env.FLUTTER_VERSION }}
+
+    - name: Commit changes
+      uses: EndBug/add-and-commit@v9
+      with:
+        add: macos
+        default_author: github_actions
+        message: 'Update macOS build files'

--- a/.github/workflows/pr-ci-app-win-x64.yml
+++ b/.github/workflows/pr-ci-app-win-x64.yml
@@ -213,18 +213,12 @@ jobs:
       run: |
         &"${Env:ProgramFiles(x86)}/Inno Setup 6/iscc.exe" "${{ env.DEV_DRIVE }}/momentobooth/windows/installer/installer.iss"
 
-    - name: Archive release
-      uses: thedoctor0/zip-release@0.7.6
-      with:
-        type: zip
-        directory: ${{ env.DEV_DRIVE }}/momentobooth/build/windows/x64/runner/Release
-        filename: MomentoBooth-Win-x64.zip
-
     - name: Upload zip artifact
       uses: actions/upload-artifact@v4
       with:
         name: Windows x64 (zip)
-        path: ${{ env.DEV_DRIVE }}/momentobooth/build/windows/x64/runner/Release/MomentoBooth-Win-x64.zip
+        path: ${{ env.DEV_DRIVE }}/momentobooth/build/windows/x64/runner/Release/*
+        compression-level: 9
 
     - name: Upload installer artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-ci-app-win-x64.yml
+++ b/.github/workflows/pr-ci-app-win-x64.yml
@@ -28,7 +28,7 @@ jobs:
     # Inspired by: https://github.com/astral-sh/uv/blob/main/.github/workflows/ci.yml
     - name: Create Dev Drive using ReFS
       run: |
-        $Volume = New-VHD -Path D:/mb_dev_drive.vhdx -SizeBytes 10GB |
+        $Volume = New-VHD -Path D:/mb_dev_drive.vhdx -SizeBytes 20GB |
                   Mount-VHD -Passthru |
                   Initialize-Disk -Passthru |
                   New-Partition -AssignDriveLetter -UseMaximumSize |

--- a/.github/workflows/release-linux-appimage-x64.yml
+++ b/.github/workflows/release-linux-appimage-x64.yml
@@ -139,5 +139,6 @@ jobs:
         allowUpdates: true
         prerelease: true
         replacesArtifacts: true
+        omitBodyDuringUpdate: true
         tag: ${{ steps.extract_release_version.outputs.release_version }}
         artifacts: "MomentoBooth-${{ steps.extract_release_version.outputs.release_version }}-Linux-x86_64.AppImage"

--- a/.github/workflows/release-win-x64.yml
+++ b/.github/workflows/release-win-x64.yml
@@ -227,6 +227,7 @@ jobs:
         type: zip
         directory: ${{ env.DEV_DRIVE }}/momentobooth/build/windows/x64/runner/Release
         filename: 'MomentoBooth-${{ steps.extract_release_version.outputs.release_version }}-Win-x64.zip'
+        custom: -mx9
 
     - name: Create GitHub release
       uses: ncipollo/release-action@v1

--- a/.github/workflows/release-win-x64.yml
+++ b/.github/workflows/release-win-x64.yml
@@ -27,7 +27,7 @@ jobs:
     # Inspired by: https://github.com/astral-sh/uv/blob/main/.github/workflows/ci.yml
     - name: Create Dev Drive using ReFS
       run: |
-        $Volume = New-VHD -Path D:/mb_dev_drive.vhdx -SizeBytes 10GB |
+        $Volume = New-VHD -Path D:/mb_dev_drive.vhdx -SizeBytes 20GB |
                   Mount-VHD -Passthru |
                   Initialize-Disk -Passthru |
                   New-Partition -AssignDriveLetter -UseMaximumSize |

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -19,11 +19,11 @@ PODS:
     - FlutterMacOS
   - screen_retriever (0.0.1):
     - FlutterMacOS
-  - Sentry/HybridSDK (8.33.0)
-  - sentry_flutter (8.7.0):
+  - Sentry/HybridSDK (8.35.1)
+  - sentry_flutter (8.8.0):
     - Flutter
     - FlutterMacOS
-    - Sentry/HybridSDK (= 8.33.0)
+    - Sentry/HybridSDK (= 8.35.1)
   - share_plus (0.0.1):
     - FlutterMacOS
   - texture_rgba_renderer (0.0.1):
@@ -90,10 +90,10 @@ SPEC CHECKSUMS:
   package_info_plus: fa739dd842b393193c5ca93c26798dff6e3d0e0c
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   printing: 1dd6a1fce2209ec240698e2439a4adbb9b427637
-  rust_lib_momento_booth: 9aac42ff9f5beed95777582b9ed9e72d458190ff
+  rust_lib_momento_booth: 4e5594669c480f4194443894fb01f2e1c512ca0d
   screen_retriever: 59634572a57080243dd1bf715e55b6c54f241a38
-  Sentry: 8560050221424aef0bebc8e31eedf00af80f90a6
-  sentry_flutter: e26b861f744e5037a3faf9bf56603ec65d658a61
+  Sentry: 1fe34e9c2cbba1e347623610d26db121dcb569f1
+  sentry_flutter: a39c2a2d67d5e5b9cb0b94a4985c76dd5b3fc737
   share_plus: 36537c04ce0c3e3f5bd297ce4318b6d5ee5fd6cf
   texture_rgba_renderer: cbed959a3c127122194a364e14b8577bd62dc8f2
   window_manager: 3a1844359a6295ab1e47659b1a777e36773cd6e8

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -426,10 +426,10 @@ packages:
     dependency: transitive
     description:
       name: flex_seed_scheme
-      sha256: cc08c81879ecfd2ab840664ce4770980da0b8a319e35f51bcf763849b7f7596b
+      sha256: "86470c8dc470f55dd3e28a6d30e3253a1c176df32903263d7daeabfc0c77dbd4"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.2.0"
   fluent_ui:
     dependency: "direct main"
     description:
@@ -710,10 +710,10 @@ packages:
     dependency: "direct main"
     description:
       name: just_audio
-      sha256: ee50602364ba83fa6308f5512dd560c713ec3e1f2bc75f0db43618f0d82ef71a
+      sha256: d8e8aaf417d33e345299c17f6457f72bd4ba0c549dc34607abb5183a354edc4d
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.39"
+    version: "0.9.40"
   just_audio_media_kit:
     dependency: "direct main"
     description:
@@ -734,10 +734,10 @@ packages:
     dependency: transitive
     description:
       name: just_audio_web
-      sha256: "0edb481ad4aa1ff38f8c40f1a3576013c3420bf6669b686fe661627d49bc606c"
+      sha256: b163878529d9b028c53a6972fcd58cae2405bcd11cbfcea620b6fb9f151429d6
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.11"
+    version: "0.4.12"
   leak_tracker:
     dependency: transitive
     description:
@@ -870,10 +870,10 @@ packages:
     dependency: transitive
     description:
       name: mime
-      sha256: "2e123074287cc9fd6c09de8336dae606d1ddb88d9ac47358826db698c176a1f2"
+      sha256: "801fd0b26f14a4a58ccb09d5892c3fbdeff209594300a542492cf13fba9d247a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.5"
+    version: "1.0.6"
   mobx:
     dependency: "direct main"
     description:
@@ -1054,10 +1054,10 @@ packages:
     dependency: "direct main"
     description:
       name: printing
-      sha256: cc4b256a5a89d5345488e3318897b595867f5181b8c5ed6fc63bfa5f2044aec3
+      sha256: de1889f30b34029fc46e5de6a9841498850b23d32942a9ee810ca36b0cb1b234
       url: "https://pub.dev"
     source: hosted
-    version: "5.13.1"
+    version: "5.13.2"
   provider:
     dependency: transitive
     description:
@@ -1094,10 +1094,10 @@ packages:
     dependency: transitive
     description:
       name: quiver
-      sha256: b1c1ac5ce6688d77f65f3375a9abb9319b3cb32486bdc7a1e0fdf004d7ba4e47
+      sha256: ea0b925899e64ecdfbf9c7becb60d5b50e706ade44a85b2363be2a22d88117d2
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.2"
   recase:
     dependency: transitive
     description:
@@ -1165,34 +1165,34 @@ packages:
     dependency: transitive
     description:
       name: sentry
-      sha256: "0f787e27ff617e4f88f7074977240406a9c5509444bac64a4dfa5b3200fb5632"
+      sha256: "1af8308298977259430d118ab25be8e1dda626cdefa1e6ce869073d530d39271"
       url: "https://pub.dev"
     source: hosted
-    version: "8.7.0"
+    version: "8.8.0"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
-      sha256: fbbb47d72ccca48be25bf3c2ced6ab6e872991af3a0ba78e54be8d138f2e053f
+      sha256: "18fe4d125c2d529bd6127200f0d2895768266a8c60b4fb50b2086fd97e1a4ab2"
       url: "https://pub.dev"
     source: hosted
-    version: "8.7.0"
+    version: "8.8.0"
   share_plus:
     dependency: transitive
     description:
       name: share_plus
-      sha256: ef3489a969683c4f3d0239010cc8b7a2a46543a8d139e111c06c558875083544
+      sha256: "468c43f285207c84bcabf5737f33b914ceb8eb38398b91e5e3ad1698d1b72a52"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "10.0.2"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: "0f9e4418835d1b2c3ae78fdb918251959106cefdbc4dd43526e182f80e82f6d4"
+      sha256: "6ababf341050edff57da8b6990f11f4e99eaba837865e2e6defe16d039619db5"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "5.0.0"
   shelf:
     dependency: transitive
     description:
@@ -1306,10 +1306,10 @@ packages:
     dependency: "direct main"
     description:
       name: talker_flutter
-      sha256: a24b977f1241714f18d714e2675a97cb9ac15c18ac602edf9426dd85f15cfd60
+      sha256: "51e1f26a726dced6952c2070ae2bc7e23393c319e2f98def2009fdbcdfbda7aa"
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.0"
+    version: "4.4.1"
   talker_logger:
     dependency: transitive
     description:
@@ -1435,10 +1435,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: "83d37c7ad7aaf9aa8e275490669535c8080377cfa7a7004c24dfac53afffaa90"
+      sha256: f33d6bb662f0e4f79dcd7ada2e6170f3b3a2530c28fc41f49a411ddedd576a77
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.2"
+    version: "4.5.0"
   vector_graphics:
     dependency: transitive
     description:
@@ -1499,10 +1499,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      sha256: d43c1d6b787bf0afad444700ae7f4db8827f701bc61c255ac8d328c6f4d52062
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "1.0.0"
   web_socket:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,7 +52,7 @@ dependencies:
   flutter_rust_bridge: 2.3.0
 
   # Printing
-  printing: 5.13.1
+  printing: 5.13.2
   pdf: 3.11.1
 
   # System
@@ -64,11 +64,11 @@ dependencies:
 
   # Log and error handling
   talker: 4.4.1
-  talker_flutter: 4.4.0
-  sentry_flutter: 8.7.0
+  talker_flutter: 4.4.1
+  sentry_flutter: 8.8.0
 
   # Sound output
-  just_audio: 0.9.39
+  just_audio: 0.9.40
   just_audio_media_kit: 2.0.5
   media_kit_libs_linux: any
   media_kit_libs_windows_audio: any

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -116,7 +116,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -262,7 +262,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.76",
+ "syn 2.0.77",
  "which",
 ]
 
@@ -283,7 +283,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -381,9 +381,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd4c6dcc3b0aea2f5c0b4b82c2b15fe39ddbc76041a310848f4706edf76bb31"
+checksum = "773d90827bc3feecfb67fab12e24de0749aad83c74b9504ecde46237b5cd24e2"
 
 [[package]]
 name = "byteorder"
@@ -415,9 +415,9 @@ checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cc"
-version = "1.1.14"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d2eb3cd3d1bf4529e31c215ee6f93ec5a3d536d9f578f93d9d33ee19562932"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
  "jobserver",
  "libc",
@@ -801,7 +801,7 @@ checksum = "51aac4c99b2e6775164b412ea33ae8441b2fde2dbf05a20bc0052a63d08c475b"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -916,7 +916,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -927,7 +927,7 @@ checksum = "ba7795da175654fe16979af73f81f26a8ea27638d8d9823d317016888a63dc4c"
 dependencies = [
  "num-traits",
  "quote 1.0.37",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1105,7 +1105,7 @@ dependencies = [
  "md-5",
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1222,7 +1222,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1675,18 +1675,6 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
-dependencies = [
- "bytemuck",
- "byteorder",
- "color_quant",
- "num-traits",
-]
-
-[[package]]
-name = "image"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99314c8a2152b8ddb211f924cdae532d8c5e4c8bb54728e12fff1b0cd5963a10"
@@ -1737,9 +1725,9 @@ checksum = "44feda355f4159a7c757171a77de25daf6411e217b4cabd03bd6650690468126"
 
 [[package]]
 name = "indexmap"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1762,7 +1750,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2241,10 +2229,10 @@ dependencies = [
 [[package]]
 name = "nokhwa"
 version = "0.10.4"
-source = "git+https://github.com/l1npengtul/nokhwa.git?rev=74a98ace10368320cfcc2186118ae10d5308ca59#74a98ace10368320cfcc2186118ae10d5308ca59"
+source = "git+https://github.com/kendfrey/nokhwa.git?branch=0.10#804a4147d5910ae98422c0dcd3b8430406f3acb9"
 dependencies = [
  "flume 0.10.14",
- "image 0.24.9",
+ "image",
  "nokhwa-bindings-linux",
  "nokhwa-bindings-macos",
  "nokhwa-bindings-windows",
@@ -2257,7 +2245,7 @@ dependencies = [
 [[package]]
 name = "nokhwa-bindings-linux"
 version = "0.1.0"
-source = "git+https://github.com/l1npengtul/nokhwa.git?rev=74a98ace10368320cfcc2186118ae10d5308ca59#74a98ace10368320cfcc2186118ae10d5308ca59"
+source = "git+https://github.com/kendfrey/nokhwa.git?branch=0.10#804a4147d5910ae98422c0dcd3b8430406f3acb9"
 dependencies = [
  "nokhwa-core",
  "v4l",
@@ -2267,7 +2255,7 @@ dependencies = [
 [[package]]
 name = "nokhwa-bindings-macos"
 version = "0.2.1"
-source = "git+https://github.com/l1npengtul/nokhwa.git?rev=74a98ace10368320cfcc2186118ae10d5308ca59#74a98ace10368320cfcc2186118ae10d5308ca59"
+source = "git+https://github.com/kendfrey/nokhwa.git?branch=0.10#804a4147d5910ae98422c0dcd3b8430406f3acb9"
 dependencies = [
  "block",
  "cocoa-foundation",
@@ -2283,7 +2271,7 @@ dependencies = [
 [[package]]
 name = "nokhwa-bindings-windows"
 version = "0.4.0"
-source = "git+https://github.com/l1npengtul/nokhwa.git?rev=74a98ace10368320cfcc2186118ae10d5308ca59#74a98ace10368320cfcc2186118ae10d5308ca59"
+source = "git+https://github.com/kendfrey/nokhwa.git?branch=0.10#804a4147d5910ae98422c0dcd3b8430406f3acb9"
 dependencies = [
  "nokhwa-core",
  "once_cell",
@@ -2293,10 +2281,10 @@ dependencies = [
 [[package]]
 name = "nokhwa-core"
 version = "0.1.2"
-source = "git+https://github.com/l1npengtul/nokhwa.git?rev=74a98ace10368320cfcc2186118ae10d5308ca59#74a98ace10368320cfcc2186118ae10d5308ca59"
+source = "git+https://github.com/kendfrey/nokhwa.git?branch=0.10#804a4147d5910ae98422c0dcd3b8430406f3acb9"
 dependencies = [
  "bytes 1.7.1",
- "image 0.24.9",
+ "image",
  "mozjpeg",
  "thiserror",
 ]
@@ -2358,7 +2346,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2432,9 +2420,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.3"
+version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
+checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
  "memchr",
 ]
@@ -2480,7 +2468,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2608,7 +2596,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2658,7 +2646,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2 1.0.86",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2701,7 +2689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8021cf59c8ec9c432cfc2526ac6b8aa508ecaf29cd415f271b8406c1b851c3fd"
 dependencies = [
  "quote 1.0.37",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3103,9 +3091,9 @@ dependencies = [
 
 [[package]]
 name = "rgb"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f86ae463694029097b846d8f99fd5536740602ae00022c0c50c5600720b2f71"
+checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
 dependencies = [
  "bytemuck",
 ]
@@ -3156,7 +3144,7 @@ dependencies = [
  "flutter_rust_bridge",
  "gexiv2-sys",
  "gphoto2",
- "image 0.25.2",
+ "image",
  "img-parts",
  "ipp",
  "jpeg-encoder",
@@ -3202,9 +3190,9 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver 1.0.23",
 ]
@@ -3215,15 +3203,15 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
 dependencies = [
- "rustc_version 0.4.0",
+ "rustc_version 0.4.1",
  "semver 1.0.23",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -3377,7 +3365,7 @@ checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3617,9 +3605,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.76"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
@@ -3711,7 +3699,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3800,9 +3788,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.3"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
  "bytes 1.7.1",
@@ -4250,7 +4238,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.76",
+ "syn 2.0.77",
  "wasm-bindgen-shared",
 ]
 
@@ -4284,7 +4272,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.76",
+ "syn 2.0.77",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4708,7 +4696,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -23,7 +23,7 @@ noise = "0.9.0"
 dashmap = "6.0.1"
 turborand = "0.10.1"
 pathsep = "0.1.1"
-tokio = { version = "1.39.3", features = ["rt-multi-thread"] }
+tokio = { version = "1.40.0", features = ["rt-multi-thread"] }
 gphoto2 = "3.3.1"
 ahash = "0.8.11"
 img-parts = "0.3.0"
@@ -37,16 +37,12 @@ gexiv2-sys = "1.4.0"
 regex = "1.10.6"
 log = "0.4.22"
 flutter_logger = "0.6.1"
-nokhwa = { git = "https://github.com/l1npengtul/nokhwa.git", rev = "74a98ace10368320cfcc2186118ae10d5308ca59", default-features = true, features = ["input-native", "output-threaded", "flume"] }
+nokhwa = { version = "0.10.4", features = ["input-native", "output-threaded", "flume"], git = "https://github.com/kendfrey/nokhwa.git", branch = "0.10" }
 rustc_version_runtime = "0.3.0"
 
 [build-dependencies]
 bindgen = "0.70.1"
 pkg-config = "0.3.30"
-
-[patch.crates-io]
-# patch nokhwa core until https://github.com/l1npengtul/nokhwa/pull/178 is merged and released
-nokhwa-core = { git = "https://github.com/l1npengtul/nokhwa.git", rev = "74a98ace10368320cfcc2186118ae10d5308ca59" }
 
 [profile.dev]
 opt-level = 3


### PR DESCRIPTION
This PR:
- Updates the Dart and Rust dependencies
- Raises the .zip compression level for Windows pipelines to make packages smaller
- Removes the `Podfile.lock` prior to building the macOS version, forcing it to be recreated; It then commits any changes to the macOS build folder to make sure the macOS build files are up to date