### PR TITLE
Update FRB version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Check the online documentation at [https://momentobooth.github.io/momentobooth/]
   <summary>All platforms:</summary>
 
 * `flutter_rust_bridge_codegen`
-  * Install using Cargo: `cargo install flutter_rust_bridge_codegen --version 2.5.1`
+  * Install using Cargo: `cargo install flutter_rust_bridge_codegen --version 2.6.0`
 * Flutter SDK 3.24.0+
   * Be sure that the `flutter` command is available globally as `flutter_rust_bridge_codegen` needs it\
     This is especially important when using Flutter SDK managers like `asdf` or `fvm`


### PR DESCRIPTION
Correct the version of `flutter_rust_bridge_codegen` in the documentation to reflect the latest release.