### PR TITLE
Project based workflow, menu bar, basic CLI

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -3,4 +3,9 @@ template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
 synthetic-package: false
 output-dir: lib/l10n/generated
-
+# Flutter extract to ARB plugin specific
+# key-prefix: AppLocalizations.of(context)!.
+key-prefix: localizations.
+main-locale: en
+update-all-arb-files: true
+# auto-translate: true

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -9,7 +9,6 @@ import 'package:momento_booth/app_localizations.dart';
 import 'package:momento_booth/extensions/go_router_extension.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/_all.dart';
-import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/views/base/full_screen_dialog.dart';
 import 'package:momento_booth/views/base/settings_based_transition_page.dart';
 import 'package:momento_booth/views/onboarding_screen/onboarding_screen.dart';

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -51,27 +51,18 @@ class _ShellState extends State<Shell> with WindowListener {
   Widget build(BuildContext context) {
     return _HotkeyResponder(
       router: _router,
-      child:
-      Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          _menuBarWrapper(context, _router),
-          Expanded(
-            child: FluentApp.router(
-              scrollBehavior: ScrollConfiguration.of(context),
-              routerConfig: _router,
-              localizationsDelegates: const [
-                AppLocalizations.delegate,
-                GlobalMaterialLocalizations.delegate,
-                GlobalWidgetsLocalizations.delegate,
-                GlobalCupertinoLocalizations.delegate,
-                FluentLocalizations.delegate,
-              ],
-              supportedLocales: const [Locale('en')],
-              locale: const Locale('en'),
-            ),
-          ),
+      child: FluentApp.router(
+        scrollBehavior: ScrollConfiguration.of(context),
+        routerConfig: _router,
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+          FluentLocalizations.delegate,
         ],
+        supportedLocales: const [Locale('en')],
+        locale: const Locale('en'),
       ),
     );
   }
@@ -89,57 +80,4 @@ class _ShellState extends State<Shell> with WindowListener {
     await windowManager.destroy();
   }
 
-}
-
-Widget _menuBarWrapper(BuildContext context, GoRouter router) {
-  return FluentTheme(data: FluentThemeData(),
-    child: Directionality(
-      textDirection: TextDirection.ltr,
-      child: Container(
-        color: Color(0xFFFFFFFF),
-        child: _menuBar(context, router)
-      ),
-    )
-  );
-}
-
-Widget _menuBar(BuildContext context, GoRouter router) {
-  return MenuBar(
-    items: [
-      MenuBarItem(title: 'File', items: [
-        MenuFlyoutSubItem(
-          text: const Text('Recent projects'),
-          items: (context) {
-            return [
-              MenuFlyoutItem(
-                text: const Text('Plain Text Documents'),
-                onPressed: () {},
-              ),
-              MenuFlyoutItem(
-                text: const Text('Rich Text Documents'),
-                onPressed: () {},
-              ),
-              MenuFlyoutItem(
-                text: const Text('Other Formats'),
-                onPressed: () {},
-              ),
-            ];
-          },
-        ),
-        MenuFlyoutItem(text: const Text('Open'), onPressed: getIt<ProjectManager>().browseOpen),
-        MenuFlyoutItem(text: const Text('Settings'), onPressed: () { router.push("/settings"); }),
-        const MenuFlyoutSeparator(),
-        MenuFlyoutItem(text: const Text('Exit'), onPressed: () {}),
-      ]),
-      MenuBarItem(title: 'Edit', items: [
-        MenuFlyoutItem(text: const Text('Undo'), onPressed: () {}),
-        MenuFlyoutItem(text: const Text('Cut'), onPressed: () {}),
-        MenuFlyoutItem(text: const Text('Copy'), onPressed: () {}),
-        MenuFlyoutItem(text: const Text('Paste'), onPressed: () {}),
-      ]),
-      MenuBarItem(title: 'Help', items: [
-        MenuFlyoutItem(text: const Text('About'), onPressed: () {}),
-      ]),
-    ],
-  );
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -51,18 +51,27 @@ class _ShellState extends State<Shell> with WindowListener {
   Widget build(BuildContext context) {
     return _HotkeyResponder(
       router: _router,
-      child: FluentApp.router(
-        scrollBehavior: ScrollConfiguration.of(context),
-        routerConfig: _router,
-        localizationsDelegates: const [
-          AppLocalizations.delegate,
-          GlobalMaterialLocalizations.delegate,
-          GlobalWidgetsLocalizations.delegate,
-          GlobalCupertinoLocalizations.delegate,
-          FluentLocalizations.delegate,
+      child:
+      Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _menuBarWrapper(context, _router),
+          Expanded(
+            child: FluentApp.router(
+              scrollBehavior: ScrollConfiguration.of(context),
+              routerConfig: _router,
+              localizationsDelegates: const [
+                AppLocalizations.delegate,
+                GlobalMaterialLocalizations.delegate,
+                GlobalWidgetsLocalizations.delegate,
+                GlobalCupertinoLocalizations.delegate,
+                FluentLocalizations.delegate,
+              ],
+              supportedLocales: const [Locale('en')],
+              locale: const Locale('en'),
+            ),
+          ),
         ],
-        supportedLocales: const [Locale('en')],
-        locale: const Locale('en'),
       ),
     );
   }
@@ -80,4 +89,57 @@ class _ShellState extends State<Shell> with WindowListener {
     await windowManager.destroy();
   }
 
+}
+
+Widget _menuBarWrapper(BuildContext context, GoRouter router) {
+  return FluentTheme(data: FluentThemeData(),
+    child: Directionality(
+      textDirection: TextDirection.ltr,
+      child: Container(
+        color: Color(0xFFFFFFFF),
+        child: _menuBar(context, router)
+      ),
+    )
+  );
+}
+
+Widget _menuBar(BuildContext context, GoRouter router) {
+  return MenuBar(
+    items: [
+      MenuBarItem(title: 'File', items: [
+        MenuFlyoutSubItem(
+          text: const Text('Recent projects'),
+          items: (context) {
+            return [
+              MenuFlyoutItem(
+                text: const Text('Plain Text Documents'),
+                onPressed: () {},
+              ),
+              MenuFlyoutItem(
+                text: const Text('Rich Text Documents'),
+                onPressed: () {},
+              ),
+              MenuFlyoutItem(
+                text: const Text('Other Formats'),
+                onPressed: () {},
+              ),
+            ];
+          },
+        ),
+        MenuFlyoutItem(text: const Text('Open'), onPressed: getIt<ProjectManager>().browseOpen),
+        MenuFlyoutItem(text: const Text('Settings'), onPressed: () { router.push("/settings"); }),
+        const MenuFlyoutSeparator(),
+        MenuFlyoutItem(text: const Text('Exit'), onPressed: () {}),
+      ]),
+      MenuBarItem(title: 'Edit', items: [
+        MenuFlyoutItem(text: const Text('Undo'), onPressed: () {}),
+        MenuFlyoutItem(text: const Text('Cut'), onPressed: () {}),
+        MenuFlyoutItem(text: const Text('Copy'), onPressed: () {}),
+        MenuFlyoutItem(text: const Text('Paste'), onPressed: () {}),
+      ]),
+      MenuBarItem(title: 'Help', items: [
+        MenuFlyoutItem(text: const Text('About'), onPressed: () {}),
+      ]),
+    ],
+  );
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -8,6 +8,7 @@ import 'package:momento_booth/app_localizations.dart';
 import 'package:momento_booth/extensions/go_router_extension.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/_all.dart';
+import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/views/base/full_screen_dialog.dart';
 import 'package:momento_booth/views/base/settings_based_transition_page.dart';
 import 'package:momento_booth/views/onboarding_screen/onboarding_screen.dart';

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:go_router/go_router.dart';
 import 'package:momento_booth/app_localizations.dart';
 import 'package:momento_booth/extensions/go_router_extension.dart';
@@ -51,18 +52,25 @@ class _ShellState extends State<Shell> with WindowListener {
   Widget build(BuildContext context) {
     return _HotkeyResponder(
       router: _router,
-      child: FluentApp.router(
-        scrollBehavior: ScrollConfiguration.of(context),
-        routerConfig: _router,
-        localizationsDelegates: const [
-          AppLocalizations.delegate,
-          GlobalMaterialLocalizations.delegate,
-          GlobalWidgetsLocalizations.delegate,
-          GlobalCupertinoLocalizations.delegate,
-          FluentLocalizations.delegate,
-        ],
-        supportedLocales: const [Locale('en')],
-        locale: const Locale('en'),
+      child: Observer(
+        builder: (context) {
+          return FluentApp.router(
+            scrollBehavior: ScrollConfiguration.of(context),
+            routerConfig: _router,
+            localizationsDelegates: const [
+              AppLocalizations.delegate,
+              GlobalMaterialLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+              FluentLocalizations.delegate,
+            ],
+            supportedLocales: const [
+              Locale('en'), // English
+              Locale('nl'), // Dutch
+            ],
+            locale: getIt<SettingsManager>().settings.ui.language.toLocale(),
+          );
+        }
       ),
     );
   }

--- a/lib/app.hotkeys.dart
+++ b/lib/app.hotkeys.dart
@@ -25,6 +25,7 @@ class _HotkeyResponder extends StatelessWidget {
           }
         },
         SingleActivator(LogicalKeyboardKey.keyF, control: control, meta: meta): () => getIt<WindowManager>().toggleFullscreen(),
+        SingleActivator(LogicalKeyboardKey.keyO, control: control, meta: meta): () => getIt<ProjectManager>().browseOpen(),
         const SingleActivator(LogicalKeyboardKey.enter, alt: true): () => getIt<WindowManager>().toggleFullscreen(),
       },
       child: child,

--- a/lib/hardware_control/photo_capturing/photo_capture_method.dart
+++ b/lib/hardware_control/photo_capturing/photo_capture_method.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:intl/intl.dart';
 import 'package:momento_booth/main.dart';
+import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/models/photo_capture.dart';
 import 'package:momento_booth/utils/file_utils.dart';
@@ -24,9 +25,10 @@ abstract class PhotoCaptureMethod with Logger {
         String currentDateTime = formatter.format(DateTime.now());
         String fileName = "${currentDateTime}_$filename";
 
-        await Directory(getIt<SettingsManager>().settings.hardware.captureStorageLocation).create(recursive: true);
+        // FIXME can I conclude that this is not necessary anymore as the folder gets created when a project is opened, or must we assume that the folder can be deleted in the mean time?
+        await getIt<ProjectManager>().getInputDir().create(recursive: true);
 
-        String filePath = path.join(getIt<SettingsManager>().settings.hardware.captureStorageLocation, fileName);
+        String filePath = path.join(getIt<ProjectManager>().getInputDir().path, fileName);
         await writeBytesToFileLocked(filePath, fileData);
         logDebug("Stored incoming photo to disk: $filePath");
       } catch (exception, stacktrace) {

--- a/lib/hardware_control/photo_capturing/photo_capture_method.dart
+++ b/lib/hardware_control/photo_capturing/photo_capture_method.dart
@@ -24,7 +24,7 @@ abstract class PhotoCaptureMethod with Logger {
         String currentDateTime = formatter.format(DateTime.now());
         String fileName = "${currentDateTime}_$filename";
 
-        // FIXME can I conclude that this is not necessary anymore as the folder gets created when a project is opened, or must we assume that the folder can be deleted in the mean time?
+        // The folder gets created when a project is opened, but the folder could be deleted in the mean time
         await getIt<ProjectManager>().getInputDir().create(recursive: true);
 
         String filePath = path.join(getIt<ProjectManager>().getInputDir().path, fileName);

--- a/lib/hardware_control/photo_capturing/photo_capture_method.dart
+++ b/lib/hardware_control/photo_capturing/photo_capture_method.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:intl/intl.dart';

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -18,7 +18,8 @@
     "genericFile": "File",
     "genericFullScreen": "Full screen",
     "genericSettings": "Settings",
-    
+    "genericCanBeChangedInSettings": "this can be changed in settings",
+
     "actionRestoreLiveView": "Restore live view",
     "actionsExit": "Exit",
 
@@ -109,6 +110,7 @@
     "projectOpenButton": "Open a project folder",
     "projectOpenShort": "Open project",
     "projectViewInExplorer": "View project in explorer",
+    "projectLoadLastOnStart": "Load last project on start up",
 
     "@multiCaptureScreenPhotoCounter": {
         "placeholders": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -11,6 +11,20 @@
     "genericRetryButton": "Retry",
     "genericCancelButton": "Cancel",
     "genericOneMomentPlease": "One moment please...",
+    "genericDocumentation": "Documentation",
+    "genericAbout": "About",
+    "genericHelp": "Help",
+    "genericView": "View",
+    "genericFile": "File",
+    "genericFullScreen": "Full screen",
+    "genericSettings": "Settings",
+    
+    "actionRestoreLiveView": "Restore live view",
+    "actionsExit": "Exit",
+
+    "screensStart": "Start screen",
+    "screensGallery": "Gallery",
+    "screensManualCollage": "Manual collage",
     
     "startScreenTouchToStartButton": "Touch to start",
     "startScreenGalleryButton": "Gallery",
@@ -86,6 +100,15 @@
     "printDialogSizeSetting": "Size:",
     "printDialogNoOfPrintsSetting": "Number of prints:",
     "printDialogSummary": "{numPrints} prints → {numImages} printed images",
+
+    "projectNotOpened": "No project opened",
+    "opened": "Opened",
+    "projectNotOpenedInstructions": "You did not open a project folder yet. Open one to start capturing.",
+    "projectNotOpenedExplanation": "MomentoBooth needs to know where to store images and look for collage templates.",
+    "projectsRecent": "Recent projects",
+    "projectOpenButton": "Open a project folder",
+    "projectOpenShort": "Open project",
+    "projectViewInExplorer": "View project in explorer",
 
     "@multiCaptureScreenPhotoCounter": {
         "placeholders": {

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -18,6 +18,7 @@
     "genericFile": "Bestand",
     "genericFullScreen": "Volledig scherm",
     "genericSettings": "Instellingen",
+    "genericCanBeChangedInSettings": "dit kan worden aangepast in de instellingen",
 
     "actionRestoreLiveView": "Reset live view",
     "actionsExit": "Sluiten",
@@ -108,5 +109,6 @@
     "projectsRecent": "Recente projecten",
     "projectOpenButton": "Open een projectmap",
     "projectOpenShort": "Open project",
-    "projectViewInExplorer": "Open projectmap in verkenner"
+    "projectViewInExplorer": "Open projectmap in verkenner",
+    "projectLoadLastOnStart": "Open het laatste project bij starten"
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -11,6 +11,20 @@
     "genericRetryButton": "Probeer opnieuw",
     "genericCancelButton": "Annuleren",
     "genericOneMomentPlease": "Een moment geduld...",
+    "genericDocumentation": "Documentatie",
+    "genericAbout": "Over",
+    "genericHelp": "Help",
+    "genericView": "Weergave",
+    "genericFile": "Bestand",
+    "genericFullScreen": "Volledig scherm",
+    "genericSettings": "Instellingen",
+
+    "actionRestoreLiveView": "Reset live view",
+    "actionsExit": "Sluiten",
+
+    "screensStart": "Startscherm",
+    "screensGallery": "Galerij",
+    "screensManualCollage": "Handmatige collage",
 
     "startScreenTouchToStartButton": "Raak aan om te beginnen",
     "startScreenGalleryButton": "Galerij",
@@ -85,5 +99,14 @@
     "printDialogTitle": "Afdrukken",
     "printDialogSizeSetting": "Formaat:",
     "printDialogNoOfPrintsSetting": "Aantal prints:",
-    "printDialogSummary": "{numPrints} prints → {numImages} geprint foto's"
+    "printDialogSummary": "{numPrints} prints → {numImages} geprint foto's",
+
+    "projectNotOpened": "Geen project geopend",
+    "opened": "Geopend op",
+    "projectNotOpenedInstructions": "Je hebt nog geen projectmap geopend. Open er een om te beginnen met foto's schieten.",
+    "projectNotOpenedExplanation": "MomentoBooth moet weten waar afbeeldingen moeten worden opgeslagen en waar collagetemplates te vinden zijn.",
+    "projectsRecent": "Recente projecten",
+    "projectOpenButton": "Open een projectmap",
+    "projectOpenShort": "Open project",
+    "projectViewInExplorer": "Open projectmap in verkenner"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -133,12 +133,8 @@ void _initializeLog() {
 }
 
 Future<void> _createPathsSafe() async {
-  // TODO Remove the global paths here, replace by project based paths
   List<String> paths = [
-    getIt<SettingsManager>().settings.templatesFolder,
-    getIt<SettingsManager>().settings.output.localFolder,
     getIt<SettingsManager>().settings.hardware.captureLocation,
-    getIt<SettingsManager>().settings.hardware.captureStorageLocation,
   ];
 
   for (String path in paths) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,7 +8,6 @@ import 'package:mobx/mobx.dart';
 import 'package:momento_booth/app.dart';
 import 'package:momento_booth/extensions/get_it_extension.dart';
 import 'package:momento_booth/managers/_all.dart';
-import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/models/_all.dart';
 import 'package:momento_booth/models/project_data.dart';
 import 'package:momento_booth/repositories/_all.dart';
@@ -105,7 +104,7 @@ Future<void> _initializeApp(ArgResults args) async {
   // Open a project if a directory is given
   // TODO decide what to do if the folder does not exist yet.
   if (args.option("open") != null)  {
-    getIt<ProjectManager>().open(args.option("open")!);
+    await getIt<ProjectManager>().open(args.option("open")!);
   }
   await getIt<WindowManager>().initializeSafe();
   if (args.flag("fullscreen")) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -70,6 +70,7 @@ Future<void> _initializeApp(ArgResults args) async {
 
     // Managers
     ..registerManager(StatsManager())
+    ..registerManager(ProjectManager())
     ..registerManager(SfxManager())
     ..registerManager(SettingsManager())
     ..registerManager(WindowManager())

--- a/lib/managers/_all.dart
+++ b/lib/managers/_all.dart
@@ -3,6 +3,7 @@ export 'mqtt_manager.dart';
 export 'notifications_manager.dart';
 export 'photos_manager.dart';
 export 'printing_manager.dart';
+export 'project_manager.dart';
 export 'settings_manager.dart';
 export 'sfx_manager.dart';
 export 'stats_manager.dart';

--- a/lib/managers/photos_manager.dart
+++ b/lib/managers/photos_manager.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/main.dart';
+import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/models/photo_capture.dart';
 import 'package:momento_booth/models/settings.dart';
@@ -33,7 +34,7 @@ abstract class PhotosManagerBase with Store {
   @computed
   bool get showLiveViewBackground => photos.isEmpty && captureMode == CaptureMode.single;
 
-  Directory get outputDir => Directory(getIt<SettingsManager>().settings.output.localFolder);
+  Directory get outputDir => getIt<ProjectManager>().getOutputDir();
   int photoNumber = 0;
   bool photoNumberChecked = false;
 

--- a/lib/managers/project_manager.dart
+++ b/lib/managers/project_manager.dart
@@ -1,0 +1,50 @@
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:ffi/ffi.dart';
+import 'package:mobx/mobx.dart';
+import 'package:momento_booth/utils/logger.dart';
+import 'package:path/path.dart';
+import 'package:win32/win32.dart';
+
+part 'project_manager.g.dart';
+
+class ProjectManager = ProjectManagerBase with _$ProjectManager;
+
+abstract class ProjectManagerBase with Store, Logger {
+
+  bool isOpen = false;
+  Directory? path;
+
+  static const subDirs = ["Input", "Output", "Templates"];
+
+  void ensureSubDirs() {
+    if (path != null) {
+      for (final subDir in subDirs){
+        Directory(join(path!.path, subDir)).createSync();
+      }
+    }
+  }
+
+  void open(String projectPath) {
+    var directory = Directory(projectPath);
+    final exists = directory.existsSync();
+    if (!exists) {
+      // todo throw error
+    }
+    path = directory;
+  }
+
+  Directory getTemplateDir() {
+    return Directory(join(path!.path, subDirs[2]));
+  }
+
+  Directory getInputDir() {
+    return Directory(join(path!.path, subDirs[2]));
+  }
+
+  Directory getOutputDir() {
+    return Directory(join(path!.path, subDirs[2]));
+  }
+
+}

--- a/lib/managers/project_manager.dart
+++ b/lib/managers/project_manager.dart
@@ -25,6 +25,8 @@ abstract class ProjectManagerBase with Store, Logger, Subsystem {
   Directory? _path;
   List<Directory> projects = [];
 
+  // Loading the settings with default values to prevent errors from use before initialization.
+  // This is fine as the initialize method overwrites the value anyway.
   @readonly
   ProjectSettings _settings = ProjectSettings();
 
@@ -145,7 +147,7 @@ abstract class ProjectManagerBase with Store, Logger, Subsystem {
     // TODO get a translation delegate in here somehow
     final pathToOpen = await getDirectoryPath(confirmButtonText: "Open folder as project");
     if (pathToOpen != null) {
-      open(pathToOpen);
+      await open(pathToOpen);
       return true;
     }
     return false;

--- a/lib/managers/project_manager.dart
+++ b/lib/managers/project_manager.dart
@@ -1,9 +1,7 @@
 import 'dart:io';
 
-import 'package:collection/collection.dart';
 import 'package:file_selector/file_selector.dart';
 import 'package:mobx/mobx.dart';
-import 'package:momento_booth/app_localizations.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/window_manager.dart';
 import 'package:momento_booth/models/project_data.dart';
@@ -18,7 +16,9 @@ class ProjectManager = ProjectManagerBase with _$ProjectManager;
 
 abstract class ProjectManagerBase with Store, Logger, Subsystem {
 
-  bool isOpen = false;
+  @readonly
+  bool _isOpen = false;
+  @readonly
   Directory? _path;
   List<Directory> projects = [];
 
@@ -49,7 +49,7 @@ abstract class ProjectManagerBase with Store, Logger, Subsystem {
     }
   }
 
-  void ensureSubDirs() {
+  void _ensureSubDirs() {
     if (_path != null) {
       for (final subDir in subDirs){
         Directory(join(_path!.path, subDir)).createSync();
@@ -80,8 +80,9 @@ abstract class ProjectManagerBase with Store, Logger, Subsystem {
     currentList.sort((a, b) => b.opened.compareTo(a.opened));
     _projectsList = _projectsList.copyWith(list: currentList);
     _path = directory;
-    isOpen = true;
+    _isOpen = true;
     getIt<WindowManager>().setTitle(entry.name);
+    _ensureSubDirs();
     _saveProjectsList();
   }
 

--- a/lib/managers/project_manager.dart
+++ b/lib/managers/project_manager.dart
@@ -1,50 +1,103 @@
-import 'dart:ffi';
+import 'dart:convert';
 import 'dart:io';
 
-import 'package:ffi/ffi.dart';
 import 'package:mobx/mobx.dart';
+import 'package:momento_booth/main.dart';
+import 'package:momento_booth/models/project_data.dart';
+import 'package:momento_booth/repositories/serializable/serializable_repository.dart';
+import 'package:momento_booth/utils/environment_info.dart';
 import 'package:momento_booth/utils/logger.dart';
+import 'package:momento_booth/utils/subsystem.dart';
 import 'package:path/path.dart';
-import 'package:win32/win32.dart';
 
 part 'project_manager.g.dart';
 
 class ProjectManager = ProjectManagerBase with _$ProjectManager;
 
-abstract class ProjectManagerBase with Store, Logger {
+abstract class ProjectManagerBase with Store, Logger, Subsystem {
 
   bool isOpen = false;
-  Directory? path;
+  Directory? _path;
+  List<Directory> projects = [];
 
   static const subDirs = ["Input", "Output", "Templates"];
+  final projectsFile = File(join(appDataPath, "Projects.json"));
+  
+  @readonly
+  late ProjectsList _projectsList;
+
+  @override
+  Future<void> initialize() async {
+    SerialiableRepository<ProjectsList> projectsListRepository = getIt<SerialiableRepository<ProjectsList>>();
+
+    try {
+      bool hasExistingProjectsList = await projectsListRepository.hasExistingData();
+
+      if (!hasExistingProjectsList) {
+        _projectsList = const ProjectsList();
+        reportSubsystemOk(message: "No existing ProjectsList data found, a new file will be created.");
+      } else {
+        _projectsList = await projectsListRepository.get();
+        reportSubsystemOk();
+      }
+    } catch (e) {
+      _projectsList = const ProjectsList();
+      reportSubsystemWarning(
+        message: "Could not read existing ProjectsList: $e\n\nThe ProjectsList have been cleared. As such the existing ProjectsList file will be overwritten.",
+      );
+    }
+  }
 
   void ensureSubDirs() {
-    if (path != null) {
+    if (_path != null) {
       for (final subDir in subDirs){
-        Directory(join(path!.path, subDir)).createSync();
+        Directory(join(_path!.path, subDir)).createSync();
       }
     }
   }
 
   void open(String projectPath) {
     var directory = Directory(projectPath);
-    final exists = directory.existsSync();
-    if (!exists) {
-      // todo throw error
+    final absPath = canonicalize(directory.path);
+    // Check if there is already an entry for this path in the projects list
+    final existingProjectEntry = _projectsList.list.where((e) => canonicalize(e.path) == absPath).indexed.toList();
+    if (existingProjectEntry.isEmpty) {
+      // Create directory and add entry to our projects list
+      directory.createSync();
+      _projectsList.list.add(ProjectData(opened: DateTime.now(), path: directory.path));
+    } else {
+      // Update the entry in the projects list.
+      final (index, entry) = existingProjectEntry.first;
+      final newEntry = entry.copyWith(opened: DateTime.now());
+      _projectsList.list[index] = newEntry;
     }
-    path = directory;
+    _path = directory;
+    isOpen = true;
+  }
+
+  Future<List<ProjectData>> listProjects() async {
+    return (await getIt<SerialiableRepository<ProjectsList>>().get()).list;
+  }
+
+  Future<List<String>> listProjectsAsStrings() async {
+    final parsedList = await getIt<SerialiableRepository<ProjectsList>>().get();
+    return parsedList.list.map((el) => el.path).toList();
+  }
+
+  Future<void> _saveProjectsList() async {
+    await getIt<SerialiableRepository<ProjectsList>>().write(_projectsList);
   }
 
   Directory getTemplateDir() {
-    return Directory(join(path!.path, subDirs[2]));
+    return Directory(join(_path!.path, subDirs[2]));
   }
 
   Directory getInputDir() {
-    return Directory(join(path!.path, subDirs[2]));
+    return Directory(join(_path!.path, subDirs[2]));
   }
 
   Directory getOutputDir() {
-    return Directory(join(path!.path, subDirs[2]));
+    return Directory(join(_path!.path, subDirs[2]));
   }
 
 }

--- a/lib/managers/project_manager.dart
+++ b/lib/managers/project_manager.dart
@@ -76,15 +76,17 @@ abstract class ProjectManagerBase with Store, Logger, Subsystem {
     _saveProjectsList();
   }
 
-  Future<void> browseOpen() async {
+  Future<bool> browseOpen() async {
     final pathToOpen = await getDirectoryPath(confirmButtonText: "Open folder as project");
     if (pathToOpen != null) {
       open(pathToOpen);
+      return true;
     }
+    return false;
   }
 
-  Future<List<ProjectData>> listProjects() async {
-    return (await getIt<SerialiableRepository<ProjectsList>>().get()).list;
+  List<ProjectData> listProjects() {
+    return _projectsList.list;
   }
 
   Future<List<String>> listProjectsAsStrings() async {

--- a/lib/managers/project_manager.dart
+++ b/lib/managers/project_manager.dart
@@ -1,9 +1,11 @@
 import 'dart:io';
 import 'dart:ui';
 
+import 'package:collection/collection.dart';
 import 'package:file_selector/file_selector.dart';
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/main.dart';
+import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/managers/window_manager.dart';
 import 'package:momento_booth/models/project_data.dart';
 import 'package:momento_booth/models/project_settings.dart';
@@ -65,6 +67,10 @@ abstract class ProjectManagerBase with Store, Logger, Subsystem {
         message: "Could not read existing ProjectsList: $e\n\nThe ProjectsList have been cleared. As such the existing ProjectsList file will be overwritten.",
       );
     }
+
+    if (getIt<SettingsManager>().settings.loadLastProject) {
+      await openLastProject();
+    }
   }
 
   @action
@@ -90,6 +96,10 @@ abstract class ProjectManagerBase with Store, Logger, Subsystem {
         Directory(join(_path!.path, subDir)).createSync();
       }
     }
+  }
+
+  Future<void> openLastProject() async {
+    return open(_projectsList.list.sorted((a, b) => b.opened.compareTo(a.opened)).first.path);
   }
 
   Future<void> open(String projectPath) async {

--- a/lib/managers/project_manager.dart
+++ b/lib/managers/project_manager.dart
@@ -1,14 +1,12 @@
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/models/project_data.dart';
 import 'package:momento_booth/repositories/serializable/serializable_repository.dart';
-import 'package:momento_booth/utils/environment_info.dart';
 import 'package:momento_booth/utils/logger.dart';
 import 'package:momento_booth/utils/subsystem.dart';
-import 'package:path/path.dart';
+import 'package:path/path.dart' hide context;
 
 part 'project_manager.g.dart';
 
@@ -21,7 +19,6 @@ abstract class ProjectManagerBase with Store, Logger, Subsystem {
   List<Directory> projects = [];
 
   static const subDirs = ["Input", "Output", "Templates"];
-  final projectsFile = File(join(appDataPath, "Projects.json"));
   
   @readonly
   late ProjectsList _projectsList;
@@ -93,11 +90,11 @@ abstract class ProjectManagerBase with Store, Logger, Subsystem {
   }
 
   Directory getInputDir() {
-    return Directory(join(_path!.path, subDirs[2]));
+    return Directory(join(_path!.path, subDirs[0]));
   }
 
   Directory getOutputDir() {
-    return Directory(join(_path!.path, subDirs[2]));
+    return Directory(join(_path!.path, subDirs[1]));
   }
 
 }

--- a/lib/managers/project_manager.dart
+++ b/lib/managers/project_manager.dart
@@ -58,19 +58,22 @@ abstract class ProjectManagerBase with Store, Logger, Subsystem {
     var directory = Directory(projectPath);
     final absPath = canonicalize(directory.path);
     // Check if there is already an entry for this path in the projects list
-    final existingProjectEntry = _projectsList.list.where((e) => canonicalize(e.path) == absPath).indexed.toList();
+    final List<ProjectData> currentList = List.from(_projectsList.list);
+    final existingProjectEntry = currentList.where((e) => canonicalize(e.path) == absPath).indexed.toList();
     if (existingProjectEntry.isEmpty) {
       // Create directory and add entry to our projects list
       directory.createSync();
-      _projectsList.list.add(ProjectData(opened: DateTime.now(), path: directory.path));
+      currentList.add(ProjectData(opened: DateTime.now(), path: directory.path));
     } else {
       // Update the entry in the projects list.
       final (index, entry) = existingProjectEntry.first;
       final newEntry = entry.copyWith(opened: DateTime.now());
-      _projectsList.list[index] = newEntry;
+      currentList[index] = newEntry;
     }
+    _projectsList = _projectsList.copyWith(list: currentList);
     _path = directory;
     isOpen = true;
+    _saveProjectsList();
   }
 
   Future<void> browseOpen() async {

--- a/lib/managers/project_manager.dart
+++ b/lib/managers/project_manager.dart
@@ -87,6 +87,7 @@ abstract class ProjectManagerBase with Store, Logger, Subsystem {
     }
 
     _settings = settings;
+    // TODO implement MQTT project related property publishing
     // getIt<MqttManager>().publishSettings(settings);
   }
 
@@ -118,7 +119,6 @@ abstract class ProjectManagerBase with Store, Logger, Subsystem {
     } else {
       // Update the entry in the projects list.
       final (index, currentEntry) = existingProjectEntries.first;
-      // final currentEntry = currentList.removeAt(index);
       entry = currentEntry.copyWith(opened: DateTime.now());
       currentList[index] = entry;
     }

--- a/lib/managers/project_manager.dart
+++ b/lib/managers/project_manager.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:file_selector/file_selector.dart';
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/models/project_data.dart';
@@ -70,6 +71,13 @@ abstract class ProjectManagerBase with Store, Logger, Subsystem {
     }
     _path = directory;
     isOpen = true;
+  }
+
+  Future<void> browseOpen() async {
+    final pathToOpen = await getDirectoryPath(confirmButtonText: "Open folder as project");
+    if (pathToOpen != null) {
+      open(pathToOpen);
+    }
   }
 
   Future<List<ProjectData>> listProjects() async {

--- a/lib/managers/settings_manager.dart
+++ b/lib/managers/settings_manager.dart
@@ -12,8 +12,10 @@ class SettingsManager = SettingsManagerBase with _$SettingsManager;
 
 abstract class SettingsManagerBase with Store, Logger, Subsystem {
 
+  // Loading the settings with default values to prevent errors from use before initialization.
+  // This is fine as the initialize method overwrites the value anyway.
   @readonly
-  late Settings _settings;
+  Settings _settings = Settings.withDefaults();
 
   @override
   Future<void> initialize() async {

--- a/lib/managers/settings_manager.dart
+++ b/lib/managers/settings_manager.dart
@@ -24,14 +24,12 @@ abstract class SettingsManagerBase with Store, Logger, Subsystem {
       bool hasExistingSettings = await settingsRepository.hasExistingData();
 
       if (!hasExistingSettings) {
-        _settings = Settings.withDefaults();
         reportSubsystemOk(message: "No existing settings data found, a new file will be created.");
       } else {
         _settings = await settingsRepository.get();
         reportSubsystemOk();
       }
     } catch (e) {
-      _settings = Settings.withDefaults();
       reportSubsystemError(
         message: "Could not read existing settings. Open the details view for details and solutions.",
         exception: e.toString(),

--- a/lib/managers/window_manager.dart
+++ b/lib/managers/window_manager.dart
@@ -27,9 +27,13 @@ abstract class WindowManagerBase with Store, Logger, Subsystem {
   // Methods //
   // /////// //
 
-  @action
   void toggleFullscreen() {
-    _isFullScreen = !_isFullScreen;
+    setFullscreen(!_isFullScreen);
+  }
+
+  @action
+  void setFullscreen(bool fullscreen) {
+    _isFullScreen = fullscreen;
     logDebug("Setting fullscreen to $_isFullScreen");
     windowManager.setFullScreen(_isFullScreen);
   }

--- a/lib/managers/window_manager.dart
+++ b/lib/managers/window_manager.dart
@@ -11,6 +11,7 @@ class WindowManager = WindowManagerBase with _$WindowManager;
 
 abstract class WindowManagerBase with Store, Logger, Subsystem {
 
+  @readonly
   bool _isFullScreen = false;
 
   // ////////////// //

--- a/lib/managers/window_manager.dart
+++ b/lib/managers/window_manager.dart
@@ -22,6 +22,7 @@ abstract class WindowManagerBase with Store, Logger, Subsystem {
   Future<void> initialize() async {
     await windowManager.ensureInitialized();
     _isFullScreen = await windowManager.isFullScreen();
+    setTitle("");
   }
 
   // /////// //
@@ -29,7 +30,11 @@ abstract class WindowManagerBase with Store, Logger, Subsystem {
   // /////// //
 
   void setTitle(String title) {
-    windowManager.setTitle("$title – MomentoBooth");
+    if (title.isEmpty) {
+      windowManager.setTitle("MomentoBooth");
+    } else {
+      windowManager.setTitle("$title – MomentoBooth");
+    }
   }
 
   void toggleFullscreen() {
@@ -41,6 +46,10 @@ abstract class WindowManagerBase with Store, Logger, Subsystem {
     _isFullScreen = fullscreen;
     logDebug("Setting fullscreen to $_isFullScreen");
     windowManager.setFullScreen(_isFullScreen);
+  }
+
+  void close() {
+    windowManager.close();
   }
 
 }

--- a/lib/managers/window_manager.dart
+++ b/lib/managers/window_manager.dart
@@ -27,6 +27,10 @@ abstract class WindowManagerBase with Store, Logger, Subsystem {
   // Methods //
   // /////// //
 
+  void setTitle(String title) {
+    windowManager.setTitle("$title – MomentoBooth");
+  }
+
   void toggleFullscreen() {
     setFullscreen(!_isFullScreen);
   }

--- a/lib/models/project_data.dart
+++ b/lib/models/project_data.dart
@@ -1,0 +1,35 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:toml/toml.dart';
+
+part 'project_data.freezed.dart';
+part 'project_data.g.dart';
+
+@freezed
+abstract class ProjectsList with _$ProjectsList implements TomlEncodableValue  {
+
+  const factory ProjectsList({
+    @Default([]) List<ProjectData> list,
+  }) = _ProjectsList;
+
+  factory ProjectsList.fromJson(Map<String, Object?> json) => _$ProjectsListFromJson(json);
+
+  @override
+  Map<String, dynamic> toTomlValue() => toJson();
+
+}
+
+@freezed
+abstract class ProjectData with _$ProjectData implements TomlEncodableValue  {
+
+  const factory ProjectData({
+    required String path,
+    required DateTime opened,
+    @Default("") String note,
+  }) = _ProjectData;
+
+  factory ProjectData.fromJson(Map<String, Object?> json) => _$ProjectDataFromJson(json);
+
+  @override
+  Map<String, dynamic> toTomlValue() => toJson();
+
+}

--- a/lib/models/project_data.dart
+++ b/lib/models/project_data.dart
@@ -7,6 +7,8 @@ part 'project_data.g.dart';
 @freezed
 abstract class ProjectsList with _$ProjectsList implements TomlEncodableValue  {
 
+  const ProjectsList._();
+
   const factory ProjectsList({
     @Default([]) List<ProjectData> list,
   }) = _ProjectsList;
@@ -20,6 +22,8 @@ abstract class ProjectsList with _$ProjectsList implements TomlEncodableValue  {
 
 @freezed
 abstract class ProjectData with _$ProjectData implements TomlEncodableValue  {
+
+  const ProjectData._();
 
   const factory ProjectData({
     required String path,

--- a/lib/models/project_data.dart
+++ b/lib/models/project_data.dart
@@ -1,6 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:toml/toml.dart';
 import 'package:path/path.dart' show basename;
+import 'package:toml/toml.dart';
 
 part 'project_data.freezed.dart';
 part 'project_data.g.dart';

--- a/lib/models/project_data.dart
+++ b/lib/models/project_data.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:toml/toml.dart';
+import 'package:path/path.dart' show basename;
 
 part 'project_data.freezed.dart';
 part 'project_data.g.dart';
@@ -32,6 +33,8 @@ abstract class ProjectData with _$ProjectData implements TomlEncodableValue  {
   }) = _ProjectData;
 
   factory ProjectData.fromJson(Map<String, Object?> json) => _$ProjectDataFromJson(json);
+
+  String get name => basename(path);
 
   @override
   Map<String, dynamic> toTomlValue() => toJson();

--- a/lib/models/project_settings.dart
+++ b/lib/models/project_settings.dart
@@ -1,0 +1,39 @@
+// ignore_for_file: invalid_annotation_target
+
+import 'dart:ui' as ui;
+
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:momento_booth/models/settings.dart';
+import 'package:toml/toml.dart';
+
+part 'project_settings.freezed.dart';
+part 'project_settings.g.dart';
+
+const defaultThemeColor = Color(0xFF0078C8);
+
+// ///////////// //
+// Root ProjectSettings //
+// ///////////// //
+
+@Freezed(fromJson: true, toJson: true)
+class ProjectSettings with _$ProjectSettings implements TomlEncodableValue {
+
+  const ProjectSettings._();
+
+  const factory ProjectSettings({
+    @Default(defaultThemeColor) @ColorColorCodeConverter() Color primaryColor,
+    @Default(true) bool displayConfetti,
+    @Default(false) bool customColorConfetti,
+    @Default("") String introScreenTouchToStartOverrideText,
+    @Default(true) bool singlePhotoIsCollage,
+  }) = _ProjectSettings;
+
+  factory ProjectSettings.withDefaults() => ProjectSettings.fromJson({});
+
+  factory ProjectSettings.fromJson(Map<String, Object?> json) => _$ProjectSettingsFromJson(json);
+
+  @override
+  Map<String, dynamic> toTomlValue() => toJson();
+
+}

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -29,6 +29,7 @@ class Settings with _$Settings implements TomlEncodableValue {
 
   const factory Settings({
     @Default(5) int captureDelaySeconds,
+    @Default(false) bool loadLastProject,
     @Default(1.5) double collageAspectRatio,
     @Default(0) double collagePadding,
     @JsonKey(defaultValue: _templatesFolderFromJson) required String templatesFolder,

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -31,7 +31,6 @@ class Settings with _$Settings implements TomlEncodableValue {
     @Default(5) int captureDelaySeconds,
     @Default(1.5) double collageAspectRatio,
     @Default(0) double collagePadding,
-    @Default(true) bool singlePhotoIsCollage,
     @JsonKey(defaultValue: _templatesFolderFromJson) required String templatesFolder,
     @JsonKey(defaultValue: HardwareSettings.withDefaults) required HardwareSettings hardware,
     @JsonKey(defaultValue: OutputSettings.withDefaults) required OutputSettings output,
@@ -214,13 +213,9 @@ class UiSettings with _$UiSettings implements TomlEncodableValue {
   const UiSettings._();
 
   const factory UiSettings({
-    @Default(Color(0xFF0078C8)) @ColorColorCodeConverter() Color primaryColor,
     @Default(45) int returnToHomeTimeoutSeconds,
     @Default(Language.english) Language language,
     @Default([]) List<LottieAnimationSettings> introScreenLottieAnimations,
-    @Default("") String introScreenTouchToStartOverrideText,
-    @Default(true) bool displayConfetti,
-    @Default(false) bool customColorConfetti,
     @Default(false) bool enableSfx,
     @Default("") String clickSfxFile,
     @Default("") String shareScreenSfxFile,

--- a/lib/utils/hardware.dart
+++ b/lib/utils/hardware.dart
@@ -6,6 +6,7 @@ import 'dart:typed_data';
 import 'package:ffi/ffi.dart';
 import 'package:momento_booth/exceptions/win32_exception.dart';
 import 'package:momento_booth/main.dart';
+import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/utils/file_utils.dart';
@@ -120,7 +121,7 @@ Future<Uint8List> getImagePdfWithPageSize(Uint8List imageData, PrintSize printSi
     pdfData = await getImagePDF(imageData);
   }
 
-  Directory outputDir = Directory(getIt<SettingsManager>().settings.output.localFolder);
+  Directory outputDir = getIt<ProjectManager>().getOutputDir();
   final filePath = path.join(outputDir.path, 'latest-print.pdf');
   await writeBytesToFileLocked(filePath, pdfData);
   return pdfData;

--- a/lib/views/components/dialogs/modal_dialog.dart
+++ b/lib/views/components/dialogs/modal_dialog.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:momento_booth/app_localizations.dart';
+import 'package:momento_booth/main.dart';
+import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_filled_button.dart';
 import 'package:momento_booth/views/components/dialogs/photo_booth_dialog.dart';
 import 'package:momento_booth/views/photo_booth_screen/theme/momento_booth_theme.dart';
@@ -78,7 +80,7 @@ enum ModalDialogType {
 
   Color get _iconColor {
     return switch (this) {
-      ModalDialogType.info || ModalDialogType.input => const Color(0xff0078d4),
+      ModalDialogType.info || ModalDialogType.input => getIt<ProjectManager>().settings.primaryColor,
       ModalDialogType.warning => const Color(0xffffb900),
       ModalDialogType.error => const Color(0xffd83b01),
       ModalDialogType.success => const Color(0xff107c10),

--- a/lib/views/components/dialogs/no_project_open_dialog.dart
+++ b/lib/views/components/dialogs/no_project_open_dialog.dart
@@ -7,7 +7,6 @@ import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_filled_button.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_outlined_button.dart';
 import 'package:momento_booth/views/components/dialogs/modal_dialog.dart';
-import 'package:path/path.dart' as path;
 
 class NoProjectOpenDialog extends StatelessWidget {
 
@@ -57,7 +56,7 @@ class NoProjectOpenDialog extends StatelessWidget {
                     child: Padding(
                       padding: const EdgeInsets.all(8.0),
                       child: Column(children: [
-                        Text(path.basename(project.path), style: FluentTheme.of(context).typography.bodyStrong),
+                        Text(project.name, style: FluentTheme.of(context).typography.bodyStrong),
                         Text("Opened: ${project.opened}"),
                       ],),
                     ),

--- a/lib/views/components/dialogs/no_project_open_dialog.dart
+++ b/lib/views/components/dialogs/no_project_open_dialog.dart
@@ -25,19 +25,19 @@ class NoProjectOpenDialog extends StatelessWidget {
     final recentProjects = getIt<ProjectManager>().listProjects().take(5);
 
     return ModalDialog(
-      title: "No project opened",
+      title: localizations.projectNotOpened,
       body: Column(
         children: [
           Text(
-            "You did not open a project folder yet. Open one to start capturing.",
+            localizations.projectNotOpenedInstructions,
             style: const TextStyle(fontWeight: FontWeight.bold),
           ),
           Text(
-            "MomentoBooth needs to know where to store images and look for collage templates.",
+            localizations.projectNotOpenedExplanation,
           ),
           SizedBox(height: 20.0,),
           Text(
-            "Recent projects:",
+            "${localizations.projectsRecent}:",
           ),
           SizedBox(height: 8.0,),
           Column(
@@ -55,7 +55,7 @@ class NoProjectOpenDialog extends StatelessWidget {
                     padding: const EdgeInsets.all(8.0),
                     child: Column(children: [
                       Text(project.name, style: FluentTheme.of(context).typography.bodyStrong),
-                      Text("Opened: ${project.opened}"),
+                      Text("${localizations.opened}: ${project.opened}"),
                     ],),
                   ),
                 ),
@@ -65,7 +65,7 @@ class NoProjectOpenDialog extends StatelessWidget {
       ),
       actions: [
         PhotoBoothFilledButton(
-          title: "Open a project folder",
+          title: localizations.projectOpenButton,
           icon: LucideIcons.folderInput,
           onPressed: () async {
             final opened = await getIt<ProjectManager>().browseOpen();

--- a/lib/views/components/dialogs/no_project_open_dialog.dart
+++ b/lib/views/components/dialogs/no_project_open_dialog.dart
@@ -45,21 +45,19 @@ class NoProjectOpenDialog extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
             for (final project in recentProjects)
-              Container(
-                child: Material(
-                  color: Color.fromARGB(0, 0, 0, 0),
-                  child: InkWell(
-                    onTap: () {
-                      getIt<ProjectManager>().open(project.path);
-                      onOpened();
-                    },
-                    child: Padding(
-                      padding: const EdgeInsets.all(8.0),
-                      child: Column(children: [
-                        Text(project.name, style: FluentTheme.of(context).typography.bodyStrong),
-                        Text("Opened: ${project.opened}"),
-                      ],),
-                    ),
+              Material(
+                color: Color.fromARGB(0, 0, 0, 0),
+                child: InkWell(
+                  onTap: () {
+                    getIt<ProjectManager>().open(project.path);
+                    onOpened();
+                  },
+                  child: Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: Column(children: [
+                      Text(project.name, style: FluentTheme.of(context).typography.bodyStrong),
+                      Text("Opened: ${project.opened}"),
+                    ],),
                   ),
                 ),
               )

--- a/lib/views/components/dialogs/no_project_open_dialog.dart
+++ b/lib/views/components/dialogs/no_project_open_dialog.dart
@@ -1,0 +1,91 @@
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+import 'package:momento_booth/app_localizations.dart';
+import 'package:momento_booth/main.dart';
+import 'package:momento_booth/managers/project_manager.dart';
+import 'package:momento_booth/views/components/buttons/photo_booth_filled_button.dart';
+import 'package:momento_booth/views/components/buttons/photo_booth_outlined_button.dart';
+import 'package:momento_booth/views/components/dialogs/modal_dialog.dart';
+import 'package:path/path.dart' as path;
+
+class NoProjectOpenDialog extends StatelessWidget {
+
+  // final VoidCallback onIgnorePressed;
+  final VoidCallback onOpened;
+
+  const NoProjectOpenDialog({
+    super.key,
+    // required this.onIgnorePressed,
+    required this.onOpened,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    AppLocalizations localizations = AppLocalizations.of(context)!;
+
+    final recentProjects = getIt<ProjectManager>().listProjects().take(5);
+
+    return ModalDialog(
+      title: "No project opened",
+      body: Column(
+        children: [
+          Text(
+            "You did not open a project folder yet. Open one to start capturing.",
+            style: const TextStyle(fontWeight: FontWeight.bold),
+          ),
+          Text(
+            "MomentoBooth needs to know where to store images and look for collage templates.",
+          ),
+          SizedBox(height: 20.0,),
+          Text(
+            "Recent projects:",
+          ),
+          SizedBox(height: 8.0,),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+            for (final project in recentProjects)
+              Container(
+                child: Material(
+                  color: Color.fromARGB(0, 0, 0, 0),
+                  child: InkWell(
+                    onTap: () {
+                      getIt<ProjectManager>().open(project.path);
+                      onOpened();
+                    },
+                    child: Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: Column(children: [
+                        Text(path.basename(project.path), style: FluentTheme.of(context).typography.bodyStrong),
+                        Text("Opened: ${project.opened}"),
+                      ],),
+                    ),
+                  ),
+                ),
+              )
+          ],)
+        ],
+      ),
+      actions: [
+        // PhotoBoothOutlinedButton(
+        //   title: localizations.printerErrorIgnoreButton,
+        //   icon: LucideIcons.clockArrowUp,
+        //   onPressed: onIgnorePressed,
+        // ),
+        PhotoBoothFilledButton(
+          title: "Open a project folder",
+          icon: LucideIcons.folderInput,
+          onPressed: () async {
+            final opened = await getIt<ProjectManager>().browseOpen();
+            if (opened) {
+              onOpened();
+            }
+          },
+        ),
+      ],
+      dialogType: ModalDialogType.warning,
+    );
+  }
+
+}

--- a/lib/views/components/dialogs/no_project_open_dialog.dart
+++ b/lib/views/components/dialogs/no_project_open_dialog.dart
@@ -5,7 +5,6 @@ import 'package:momento_booth/app_localizations.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_filled_button.dart';
-import 'package:momento_booth/views/components/buttons/photo_booth_outlined_button.dart';
 import 'package:momento_booth/views/components/dialogs/modal_dialog.dart';
 
 class NoProjectOpenDialog extends StatelessWidget {
@@ -65,11 +64,6 @@ class NoProjectOpenDialog extends StatelessWidget {
         ],
       ),
       actions: [
-        // PhotoBoothOutlinedButton(
-        //   title: localizations.printerErrorIgnoreButton,
-        //   icon: LucideIcons.clockArrowUp,
-        //   onPressed: onIgnorePressed,
-        // ),
         PhotoBoothFilledButton(
           title: "Open a project folder",
           icon: LucideIcons.folderInput,

--- a/lib/views/components/dialogs/no_project_open_dialog.dart
+++ b/lib/views/components/dialogs/no_project_open_dialog.dart
@@ -4,6 +4,7 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:momento_booth/app_localizations.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/project_manager.dart';
+import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/views/components/buttons/photo_booth_filled_button.dart';
 import 'package:momento_booth/views/components/dialogs/modal_dialog.dart';
 
@@ -60,7 +61,21 @@ class NoProjectOpenDialog extends StatelessWidget {
                   ),
                 ),
               )
-          ],)
+            ],
+          ),
+          SizedBox(height: 8.0,),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(localizations.projectLoadLastOnStart),
+              SizedBox(width: 8.0,),
+              ToggleSwitch(
+                checked: getIt<SettingsManager>().settings.loadLastProject,
+                onChanged: (val) => getIt<SettingsManager>().updateAndSave(getIt<SettingsManager>().settings.copyWith(loadLastProject: val)),
+              ),
+            ],
+          ),
+          Text("(${localizations.genericCanBeChangedInSettings})"),
         ],
       ),
       actions: [

--- a/lib/views/components/dialogs/print_dialog.dart
+++ b/lib/views/components/dialogs/print_dialog.dart
@@ -1,4 +1,5 @@
-import 'package:flutter/material.dart';
+import 'package:fluent_ui/fluent_ui.dart' show Colors, FluentTheme;
+import 'package:flutter/material.dart' hide Colors;
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:momento_booth/app_localizations.dart';
 import 'package:momento_booth/main.dart';
@@ -82,6 +83,7 @@ class _PrintDialogState extends State<PrintDialog> {
           Material(
             color: Colors.transparent,
             child: Slider(
+              activeColor: FluentTheme.of(context).accentColor,
               value: numPrints.toDouble(),
               min: 1,
               max: widget.maxPrints.toDouble(),
@@ -122,6 +124,17 @@ class PrintSizeChoice extends StatelessWidget {
   Widget build(BuildContext context) {
     final settings = getIt<SettingsManager>().settings.hardware.printLayoutSettings;
     return SegmentedButton<PrintSize>(
+      style: ButtonStyle(
+        backgroundColor: WidgetStateProperty.resolveWith<Color>(
+          (states) {
+              if (states.contains(WidgetState.selected)) {
+                return FluentTheme.of(context).accentColor;
+              }
+              return Colors.transparent;
+            },
+        ),
+        iconColor: WidgetStateProperty.all(Colors.white)
+      ),
       segments: [
         const ButtonSegment<PrintSize>(
           value: PrintSize.normal,

--- a/lib/views/components/imaging/live_view.dart
+++ b/lib/views/components/imaging/live_view.dart
@@ -56,9 +56,11 @@ class LiveView extends StatelessWidget {
     );
 
     if (blur) {
-      return ImageFiltered(
-        imageFilter: ImageFilter.blur(sigmaX: 8, sigmaY: 8),
-        child: box,
+      return ClipRect(
+        child: ImageFiltered(
+          imageFilter: ImageFilter.blur(sigmaX: 8, sigmaY: 8),
+          child: box,
+        ),
       );
     } else {
       return box;

--- a/lib/views/components/imaging/live_view_background.dart
+++ b/lib/views/components/imaging/live_view_background.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:momento_booth/extensions/go_router_extension.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/_all.dart';
+import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/views/components/imaging/live_view.dart';
 import 'package:momento_booth/views/photo_booth_screen/screens/gallery_screen/gallery_screen.dart';
@@ -88,7 +89,7 @@ class _LiveViewBackgroundState extends State<LiveViewBackground> {
 
   Widget get _initializingState {
     return Center(
-      child: ProgressRing(activeColor: getIt<SettingsManager>().settings.ui.primaryColor),
+      child: ProgressRing(activeColor: getIt<ProjectManager>().settings.primaryColor),
     );
   }
 

--- a/lib/views/components/imaging/live_view_background.dart
+++ b/lib/views/components/imaging/live_view_background.dart
@@ -5,7 +5,6 @@ import 'package:go_router/go_router.dart';
 import 'package:momento_booth/extensions/go_router_extension.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/_all.dart';
-import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/views/components/imaging/live_view.dart';
 import 'package:momento_booth/views/photo_booth_screen/screens/gallery_screen/gallery_screen.dart';

--- a/lib/views/components/imaging/photo_collage.dart
+++ b/lib/views/components/imaging/photo_collage.dart
@@ -14,6 +14,7 @@ import 'package:mobx/mobx.dart';
 import 'package:momento_booth/app_localizations.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
+import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/models/maker_note_data.dart';
 import 'package:momento_booth/models/photo_capture.dart';
@@ -103,7 +104,7 @@ class PhotoCollageState extends State<PhotoCollage> with Logger {
   int get rotation => [0, 1, 4].contains(nChosen) ? 1 : 0;
   bool firstImageDecoded = false;
 
-  String get templatesFolder => getIt<SettingsManager>().settings.templatesFolder;
+  Directory get templatesFolder => getIt<ProjectManager>().getTemplateDir();
 
   var templates = {
     TemplateKind.front: <int, File?>{},
@@ -129,7 +130,7 @@ class PhotoCollageState extends State<PhotoCollage> with Logger {
 
   /// Checks if a given template file exists and returns it if it does.
   Future<File?> _templateTest(String fileName) async {
-    var template = File(join(templatesFolder, fileName));
+    var template = File(join(templatesFolder.path, fileName));
     if (template.existsSync()) return template;
     return null;
   }

--- a/lib/views/components/indicators/subsystem_status_list.dart
+++ b/lib/views/components/indicators/subsystem_status_list.dart
@@ -2,6 +2,7 @@ import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/_all.dart';
+import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/views/onboarding_screen/components/subsystem_status_display.dart';
 
 class SubsystemStatusList extends StatelessWidget {
@@ -21,6 +22,9 @@ class SubsystemStatusList extends StatelessWidget {
         }),
         Observer(builder: (_) {
           return SubsystemStatusDisplay(title: "Statistics", status: getIt<StatsManager>().subsystemStatus);
+        }),
+        Observer(builder: (_) {
+          return SubsystemStatusDisplay(title: "Projects", status: getIt<ProjectManager>().subsystemStatus);
         }),
         Observer(builder: (_) {
           return SubsystemStatusDisplay(title: "Live view", status: getIt<LiveViewManager>().subsystemStatus);

--- a/lib/views/components/indicators/subsystem_status_list.dart
+++ b/lib/views/components/indicators/subsystem_status_list.dart
@@ -2,7 +2,6 @@ import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/_all.dart';
-import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/views/onboarding_screen/components/subsystem_status_display.dart';
 
 class SubsystemStatusList extends StatelessWidget {

--- a/lib/views/onboarding_screen/components/onboarding_wizard.dart
+++ b/lib/views/onboarding_screen/components/onboarding_wizard.dart
@@ -1,5 +1,6 @@
 import 'package:animations/animations.dart';
 import 'package:fluent_ui/fluent_ui.dart';
+import 'package:momento_booth/views/onboarding_screen/pages/projects_page.dart';
 import 'package:momento_booth/views/onboarding_screen/pages/status_page.dart';
 import 'package:momento_booth/views/onboarding_screen/pages/welcome_page.dart';
 
@@ -24,6 +25,7 @@ class _OnboardingWizardState extends State<OnboardingWizard> {
     controller = WizardController([
       const WelcomePage(),
       const StatusPage(),
+      const ProjectsPage(),
     ]);
     super.initState();
   }

--- a/lib/views/onboarding_screen/pages/projects_page.dart
+++ b/lib/views/onboarding_screen/pages/projects_page.dart
@@ -1,9 +1,6 @@
 import 'package:fluent_ui/fluent_ui.dart';
-import 'package:flutter_svg/flutter_svg.dart';
-import 'package:get_it/get_it.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/project_manager.dart';
-import 'package:momento_booth/views/components/indicators/subsystem_status_list.dart';
 import 'package:momento_booth/views/onboarding_screen/components/wizard_page.dart';
 
 class ProjectsPage extends StatelessWidget {

--- a/lib/views/onboarding_screen/pages/projects_page.dart
+++ b/lib/views/onboarding_screen/pages/projects_page.dart
@@ -1,0 +1,44 @@
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:get_it/get_it.dart';
+import 'package:momento_booth/main.dart';
+import 'package:momento_booth/managers/project_manager.dart';
+import 'package:momento_booth/views/components/indicators/subsystem_status_list.dart';
+import 'package:momento_booth/views/onboarding_screen/components/wizard_page.dart';
+
+class ProjectsPage extends StatelessWidget {
+
+  const ProjectsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return WizardPage(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(32, 24, 32, 24),
+        child: Column(
+          // crossAxisAlignment: CrossAxisAlignment.stretch,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: Text(
+                "Let's open your first project!",
+                style: FluentTheme.of(context).typography.title,
+              ),
+            ),
+            SizedBox(height: 16.0,),
+            Text(
+              "Open a directory (create one if you like) to use for a project. This directory will be used to store your pictures and collages. It is also where MomentoBooth will look for templates.",
+              style: FluentTheme.of(context).typography.body,
+            ),
+            SizedBox(height: 16.0,),
+            FilledButton(
+              onPressed: () { getIt<ProjectManager>().browseOpen(); },
+              child: Text("Open folder"),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+
+}

--- a/lib/views/photo_booth_screen/photo_booth.dart
+++ b/lib/views/photo_booth_screen/photo_booth.dart
@@ -56,7 +56,9 @@ class PhotoBoothState extends State<PhotoBooth> {
     return Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          _menuBar(context, _router),
+          Observer(
+            builder: (context) => !getIt<WindowManager>().isFullScreen ? _menuBar(context, _router) : SizedBox()
+          ),
           Expanded(
             child: FramerateMonitor(
               child: LiveViewBackground(

--- a/lib/views/photo_booth_screen/photo_booth.dart
+++ b/lib/views/photo_booth_screen/photo_booth.dart
@@ -8,6 +8,7 @@ import 'package:go_router/go_router.dart';
 import 'package:momento_booth/app_localizations.dart';
 import 'package:momento_booth/extensions/go_router_extension.dart';
 import 'package:momento_booth/main.dart';
+import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/utils/logger.dart';
 import 'package:momento_booth/utils/route_observer.dart';
@@ -47,46 +48,54 @@ class PhotoBoothState extends State<PhotoBooth> {
 
   @override
   Widget build(BuildContext context) {
-    return FramerateMonitor(
-      child: LiveViewBackground(
-        router: _router,
-        child: _HotkeyResponder(
-          router: _router,
-          child: ActivityMonitor(
-            router: _router,
-            child: MomentoBoothTheme(
-              data: MomentoBoothThemeData.defaults(),
-              child: SetScrollConfiguration(
-                child: Observer(
-                  builder: (context) => FluentApp.router(
-                    debugShowCheckedModeBanner: false,
-                    scrollBehavior: ScrollConfiguration.of(context),
-                    color: getIt<SettingsManager>().settings.ui.primaryColor,
-                    theme: FluentThemeData(
-                      accentColor: AccentColor.swatch(
-                        {'normal': getIt<SettingsManager>().settings.ui.primaryColor},
+    return Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _menuBar(context, _router),
+          Expanded(
+            child: FramerateMonitor(
+              child: LiveViewBackground(
+                router: _router,
+                child: _HotkeyResponder(
+                  router: _router,
+                  child: ActivityMonitor(
+                    router: _router,
+                    child: MomentoBoothTheme(
+                      data: MomentoBoothThemeData.defaults(),
+                      child: SetScrollConfiguration(
+                        child: Observer(
+                          builder: (context) => FluentApp.router(
+                            debugShowCheckedModeBanner: false,
+                            scrollBehavior: ScrollConfiguration.of(context),
+                            color: getIt<SettingsManager>().settings.ui.primaryColor,
+                            theme: FluentThemeData(
+                              accentColor: AccentColor.swatch(
+                                {'normal': getIt<SettingsManager>().settings.ui.primaryColor},
+                              ),
+                            ),
+                            routerConfig: _router,
+                            localizationsDelegates: const [
+                              AppLocalizations.delegate,
+                              GlobalMaterialLocalizations.delegate,
+                              GlobalWidgetsLocalizations.delegate,
+                              GlobalCupertinoLocalizations.delegate,
+                              FluentLocalizations.delegate,
+                            ],
+                            supportedLocales: const [
+                              Locale('en'), // English
+                              Locale('nl'), // Dutch
+                            ],
+                            locale: getIt<SettingsManager>().settings.ui.language.toLocale(),
+                          ),
+                        ),
                       ),
                     ),
-                    routerConfig: _router,
-                    localizationsDelegates: const [
-                      AppLocalizations.delegate,
-                      GlobalMaterialLocalizations.delegate,
-                      GlobalWidgetsLocalizations.delegate,
-                      GlobalCupertinoLocalizations.delegate,
-                      FluentLocalizations.delegate,
-                    ],
-                    supportedLocales: const [
-                      Locale('en'), // English
-                      Locale('nl'), // Dutch
-                    ],
-                    locale: getIt<SettingsManager>().settings.ui.language.toLocale(),
                   ),
                 ),
               ),
             ),
           ),
-        ),
-      ),
+        ]
     );
   }
 
@@ -95,4 +104,48 @@ class PhotoBoothState extends State<PhotoBooth> {
     _router.dispose();
     super.dispose();
   }
+}
+
+Widget _menuBar(BuildContext context, GoRouter router) {
+  return ColoredBox(
+    color: Color(0xFFFFFFFF),
+    child: MenuBar(
+      items: [
+        MenuBarItem(title: 'File', items: [
+          MenuFlyoutSubItem(
+            text: const Text('Recent projects'),
+            items: (context) {
+              return [
+                MenuFlyoutItem(
+                  text: const Text('Plain Text Documents'),
+                  onPressed: () {},
+                ),
+                MenuFlyoutItem(
+                  text: const Text('Rich Text Documents'),
+                  onPressed: () {},
+                ),
+                MenuFlyoutItem(
+                  text: const Text('Other Formats'),
+                  onPressed: () {},
+                ),
+              ];
+            },
+          ),
+          MenuFlyoutItem(text: const Text('Open'), onPressed: getIt<ProjectManager>().browseOpen),
+          MenuFlyoutItem(text: const Text('Settings'), onPressed: () { router.push("/settings"); }),
+          const MenuFlyoutSeparator(),
+          MenuFlyoutItem(text: const Text('Exit'), onPressed: () {}),
+        ]),
+        MenuBarItem(title: 'Edit', items: [
+          MenuFlyoutItem(text: const Text('Undo'), onPressed: () {}),
+          MenuFlyoutItem(text: const Text('Cut'), onPressed: () {}),
+          MenuFlyoutItem(text: const Text('Copy'), onPressed: () {}),
+          MenuFlyoutItem(text: const Text('Paste'), onPressed: () {}),
+        ]),
+        MenuBarItem(title: 'Help', items: [
+          MenuFlyoutItem(text: const Text('About'), onPressed: () {}),
+        ]),
+      ],
+    ),
+  );
 }

--- a/lib/views/photo_booth_screen/photo_booth.dart
+++ b/lib/views/photo_booth_screen/photo_booth.dart
@@ -114,13 +114,14 @@ class PhotoBoothState extends State<PhotoBooth> {
 }
 
 Widget _menuBar(BuildContext context, GoRouter router) {
+  AppLocalizations localizations = AppLocalizations.of(context)!;
   return ColoredBox(
     color: Color(0xFFFFFFFF),
     child: MenuBar(
       items: [
-        MenuBarItem(title: 'File', items: [
+        MenuBarItem(title: localizations.genericFile, items: [
           MenuFlyoutSubItem(
-            text: const Text('Recent projects'),
+            text: Text(localizations.projectsRecent),
             items: (context) {
               return [
                 for (final project in getIt<ProjectManager>().listProjects())
@@ -131,27 +132,27 @@ Widget _menuBar(BuildContext context, GoRouter router) {
               ];
             },
           ),
-          MenuFlyoutItem(text: const Text('Open project'), onPressed: getIt<ProjectManager>().browseOpen, leading: Icon(LucideIcons.folderInput), trailing: shortcut("Ctrl+O")),
-          MenuFlyoutItem(text: const Text('View project in explorer'), onPressed: () {
+          MenuFlyoutItem(text: Text(localizations.projectOpenShort), onPressed: getIt<ProjectManager>().browseOpen, leading: Icon(LucideIcons.folderInput), trailing: shortcut("Ctrl+O")),
+          MenuFlyoutItem(text: Text(localizations.projectViewInExplorer), onPressed: () {
             final uri = Uri.parse("file:///${getIt<ProjectManager>().path!.path}");
             launchUrl(uri);
           }, leading: Icon(LucideIcons.folderClosed)),
-          MenuFlyoutItem(text: const Text('Settings'), onPressed: () { GoRouter.of(context).push(SettingsScreen.defaultRoute); }, leading: Icon(LucideIcons.settings), trailing: shortcut("Ctrl+S")),
-          MenuFlyoutItem(text: const Text('Restore live view'), onPressed: () { getIt<LiveViewManager>().restoreLiveView(); }, leading: Icon(LucideIcons.rotateCcw), trailing: shortcut("Ctrl+R")),
+          MenuFlyoutItem(text: Text(localizations.genericSettings), onPressed: () { GoRouter.of(context).push(SettingsScreen.defaultRoute); }, leading: Icon(LucideIcons.settings), trailing: shortcut("Ctrl+S")),
+          MenuFlyoutItem(text: Text(localizations.actionRestoreLiveView), onPressed: () { getIt<LiveViewManager>().restoreLiveView(); }, leading: Icon(LucideIcons.rotateCcw), trailing: shortcut("Ctrl+R")),
           const MenuFlyoutSeparator(),
-          MenuFlyoutItem(text: const Text('Exit'), onPressed: getIt<WindowManager>().close,)
+          MenuFlyoutItem(text: Text(localizations.actionsExit), onPressed: getIt<WindowManager>().close,)
         ]),
-        MenuBarItem(title: 'View', items: [
-          MenuFlyoutItem(text: const Text('Full screen'), onPressed: () { getIt<WindowManager>().toggleFullscreen(); }, leading: Icon(LucideIcons.expand), trailing: shortcut("Ctrl+F/Alt+Enter")),
+        MenuBarItem(title: localizations.genericView, items: [
+          MenuFlyoutItem(text: Text(localizations.genericFullScreen), onPressed: () { getIt<WindowManager>().toggleFullscreen(); }, leading: Icon(LucideIcons.expand), trailing: shortcut("Ctrl+F/Alt+Enter")),
           const MenuFlyoutSeparator(),
-          MenuFlyoutItem(text: const Text('Start screen'), onPressed: () { router.go(StartScreen.defaultRoute); }, leading: Icon(LucideIcons.play), trailing: shortcut("Ctrl+H")),
-          MenuFlyoutItem(text: const Text('Gallery'), onPressed: () { router.go(GalleryScreen.defaultRoute); }, leading: Icon(LucideIcons.images)),
-          MenuFlyoutItem(text: const Text('Manual collage'), onPressed: () { router.go(ManualCollageScreen.defaultRoute); }, leading: Icon(LucideIcons.layoutDashboard), trailing: shortcut("Ctrl+M")),
+          MenuFlyoutItem(text: Text(localizations.screensStart), onPressed: () { router.go(StartScreen.defaultRoute); }, leading: Icon(LucideIcons.play), trailing: shortcut("Ctrl+H")),
+          MenuFlyoutItem(text: Text(localizations.screensGallery), onPressed: () { router.go(GalleryScreen.defaultRoute); }, leading: Icon(LucideIcons.images)),
+          MenuFlyoutItem(text: Text(localizations.screensManualCollage), onPressed: () { router.go(ManualCollageScreen.defaultRoute); }, leading: Icon(LucideIcons.layoutDashboard), trailing: shortcut("Ctrl+M")),
         ]),
-        MenuBarItem(title: 'Help', items: [
-          MenuFlyoutItem(text: const Text('Documentation'), onPressed: () { launchUrl(Uri.parse("https://momentobooth.github.io/momentobooth/")); }, leading: Icon(LucideIcons.book)),
+        MenuBarItem(title: localizations.genericHelp, items: [
+          MenuFlyoutItem(text: Text(localizations.genericDocumentation), onPressed: () { launchUrl(Uri.parse("https://momentobooth.github.io/momentobooth/")); }, leading: Icon(LucideIcons.book)),
           // TODO go to about screen in settings
-          MenuFlyoutItem(text: const Text('About'), onPressed: () { GoRouter.of(context).push(SettingsScreen.defaultRoute); }, leading: Icon(LucideIcons.info)),
+          MenuFlyoutItem(text: Text(localizations.genericAbout), onPressed: () { GoRouter.of(context).push(SettingsScreen.defaultRoute); }, leading: Icon(LucideIcons.info)),
         ]),
       ],
     ),

--- a/lib/views/photo_booth_screen/photo_booth.dart
+++ b/lib/views/photo_booth_screen/photo_booth.dart
@@ -132,11 +132,14 @@ Widget _menuBar(BuildContext context, GoRouter router) {
             },
           ),
           MenuFlyoutItem(text: const Text('Open project'), onPressed: getIt<ProjectManager>().browseOpen, leading: Icon(LucideIcons.folderInput), trailing: shortcut("Ctrl+O")),
-          MenuFlyoutItem(text: const Text('Settings'), onPressed: () { router.go("/settings"); }, leading: Icon(LucideIcons.settings), trailing: shortcut("Ctrl+S")),
+          MenuFlyoutItem(text: const Text('View project in explorer'), onPressed: () {
+            final uri = Uri.parse("file:///${getIt<ProjectManager>().path!.path}");
+            launchUrl(uri);
+          }, leading: Icon(LucideIcons.folderClosed)),
+          MenuFlyoutItem(text: const Text('Settings'), onPressed: () { GoRouter.of(context).push(SettingsScreen.defaultRoute); }, leading: Icon(LucideIcons.settings), trailing: shortcut("Ctrl+S")),
           MenuFlyoutItem(text: const Text('Restore live view'), onPressed: () { getIt<LiveViewManager>().restoreLiveView(); }, leading: Icon(LucideIcons.rotateCcw), trailing: shortcut("Ctrl+R")),
           const MenuFlyoutSeparator(),
-          // TODO I don't know how to exit nicely. Basically want to do the things currently in `app.dart` in `onWindowClose`.
-          MenuFlyoutItem(text: const Text('Exit'), onPressed: () {}),
+          MenuFlyoutItem(text: const Text('Exit'), onPressed: getIt<WindowManager>().close,)
         ]),
         MenuBarItem(title: 'View', items: [
           MenuFlyoutItem(text: const Text('Full screen'), onPressed: () { getIt<WindowManager>().toggleFullscreen(); }, leading: Icon(LucideIcons.expand), trailing: shortcut("Ctrl+F/Alt+Enter")),
@@ -148,7 +151,7 @@ Widget _menuBar(BuildContext context, GoRouter router) {
         MenuBarItem(title: 'Help', items: [
           MenuFlyoutItem(text: const Text('Documentation'), onPressed: () { launchUrl(Uri.parse("https://momentobooth.github.io/momentobooth/")); }, leading: Icon(LucideIcons.book)),
           // TODO go to about screen in settings
-          MenuFlyoutItem(text: const Text('About'), onPressed: () {}, leading: Icon(LucideIcons.info)),
+          MenuFlyoutItem(text: const Text('About'), onPressed: () { GoRouter.of(context).push(SettingsScreen.defaultRoute); }, leading: Icon(LucideIcons.info)),
         ]),
       ],
     ),

--- a/lib/views/photo_booth_screen/photo_booth.dart
+++ b/lib/views/photo_booth_screen/photo_booth.dart
@@ -36,6 +36,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 part 'photo_booth.hotkey_monitor.dart';
 part 'photo_booth.routes.dart';
+part 'photo_booth.menu.dart';
 
 class PhotoBooth extends StatefulWidget {
   const PhotoBooth({super.key});
@@ -57,7 +58,7 @@ class PhotoBoothState extends State<PhotoBooth> {
         mainAxisSize: MainAxisSize.min,
         children: [
           Observer(
-            builder: (context) => !getIt<WindowManager>().isFullScreen ? _menuBar(context, _router) : SizedBox()
+            builder: (context) => !getIt<WindowManager>().isFullScreen ? MomentoMenuBar(router: _router) : SizedBox()
           ),
           Expanded(
             child: FramerateMonitor(
@@ -111,52 +112,6 @@ class PhotoBoothState extends State<PhotoBooth> {
     _router.dispose();
     super.dispose();
   }
-}
-
-Widget _menuBar(BuildContext context, GoRouter router) {
-  AppLocalizations localizations = AppLocalizations.of(context)!;
-  return ColoredBox(
-    color: Color(0xFFFFFFFF),
-    child: MenuBar(
-      items: [
-        MenuBarItem(title: localizations.genericFile, items: [
-          MenuFlyoutSubItem(
-            text: Text(localizations.projectsRecent),
-            items: (context) {
-              return [
-                for (final project in getIt<ProjectManager>().listProjects())
-                  MenuFlyoutItem(
-                    text: Text(project.name),
-                    onPressed: () { getIt<ProjectManager>().open(project.path); },
-                  ),
-              ];
-            },
-          ),
-          MenuFlyoutItem(text: Text(localizations.projectOpenShort), onPressed: getIt<ProjectManager>().browseOpen, leading: Icon(LucideIcons.folderInput), trailing: shortcut("Ctrl+O")),
-          MenuFlyoutItem(text: Text(localizations.projectViewInExplorer), onPressed: () {
-            final uri = Uri.parse("file:///${getIt<ProjectManager>().path!.path}");
-            launchUrl(uri);
-          }, leading: Icon(LucideIcons.folderClosed)),
-          MenuFlyoutItem(text: Text(localizations.genericSettings), onPressed: () { GoRouter.of(context).push(SettingsScreen.defaultRoute); }, leading: Icon(LucideIcons.settings), trailing: shortcut("Ctrl+S")),
-          MenuFlyoutItem(text: Text(localizations.actionRestoreLiveView), onPressed: () { getIt<LiveViewManager>().restoreLiveView(); }, leading: Icon(LucideIcons.rotateCcw), trailing: shortcut("Ctrl+R")),
-          const MenuFlyoutSeparator(),
-          MenuFlyoutItem(text: Text(localizations.actionsExit), onPressed: getIt<WindowManager>().close,)
-        ]),
-        MenuBarItem(title: localizations.genericView, items: [
-          MenuFlyoutItem(text: Text(localizations.genericFullScreen), onPressed: () { getIt<WindowManager>().toggleFullscreen(); }, leading: Icon(LucideIcons.expand), trailing: shortcut("Ctrl+F/Alt+Enter")),
-          const MenuFlyoutSeparator(),
-          MenuFlyoutItem(text: Text(localizations.screensStart), onPressed: () { router.go(StartScreen.defaultRoute); }, leading: Icon(LucideIcons.play), trailing: shortcut("Ctrl+H")),
-          MenuFlyoutItem(text: Text(localizations.screensGallery), onPressed: () { router.go(GalleryScreen.defaultRoute); }, leading: Icon(LucideIcons.images)),
-          MenuFlyoutItem(text: Text(localizations.screensManualCollage), onPressed: () { router.go(ManualCollageScreen.defaultRoute); }, leading: Icon(LucideIcons.layoutDashboard), trailing: shortcut("Ctrl+M")),
-        ]),
-        MenuBarItem(title: localizations.genericHelp, items: [
-          MenuFlyoutItem(text: Text(localizations.genericDocumentation), onPressed: () { launchUrl(Uri.parse("https://momentobooth.github.io/momentobooth/")); }, leading: Icon(LucideIcons.book)),
-          // TODO go to about screen in settings
-          MenuFlyoutItem(text: Text(localizations.genericAbout), onPressed: () { GoRouter.of(context).push(SettingsScreen.defaultRoute); }, leading: Icon(LucideIcons.info)),
-        ]),
-      ],
-    ),
-  );
 }
 
 Widget shortcut(String shortcut) {

--- a/lib/views/photo_booth_screen/photo_booth.dart
+++ b/lib/views/photo_booth_screen/photo_booth.dart
@@ -74,10 +74,10 @@ class PhotoBoothState extends State<PhotoBooth> {
                           builder: (context) => FluentApp.router(
                             debugShowCheckedModeBanner: false,
                             scrollBehavior: ScrollConfiguration.of(context),
-                            color: getIt<SettingsManager>().settings.ui.primaryColor,
+                            color: getIt<ProjectManager>().settings.primaryColor,
                             theme: FluentThemeData(
                               accentColor: AccentColor.swatch(
-                                {'normal': getIt<SettingsManager>().settings.ui.primaryColor},
+                                {'normal': getIt<ProjectManager>().settings.primaryColor},
                               ),
                             ),
                             routerConfig: _router,

--- a/lib/views/photo_booth_screen/photo_booth.menu.dart
+++ b/lib/views/photo_booth_screen/photo_booth.menu.dart
@@ -1,0 +1,56 @@
+part of 'photo_booth.dart';
+
+class MomentoMenuBar extends StatelessWidget {
+
+  final GoRouter router;
+
+  const MomentoMenuBar({super.key, required this.router});
+
+  @override
+  Widget build(BuildContext context) {
+    AppLocalizations localizations = AppLocalizations.of(context)!;
+    return ColoredBox(
+      color: Color(0xFFFFFFFF),
+      child: MenuBar(
+        items: [
+          MenuBarItem(title: localizations.genericFile, items: [
+            MenuFlyoutSubItem(
+              text: Text(localizations.projectsRecent),
+              items: (context) {
+                return [
+                  for (final project in getIt<ProjectManager>().listProjects())
+                    MenuFlyoutItem(
+                      text: Text(project.name),
+                      onPressed: () { getIt<ProjectManager>().open(project.path); },
+                    ),
+                ];
+              },
+            ),
+            MenuFlyoutItem(text: Text(localizations.projectOpenShort), onPressed: getIt<ProjectManager>().browseOpen, leading: Icon(LucideIcons.folderInput), trailing: shortcut("Ctrl+O")),
+            MenuFlyoutItem(text: Text(localizations.projectViewInExplorer), onPressed: () {
+              final uri = Uri.parse("file:///${getIt<ProjectManager>().path!.path}");
+              launchUrl(uri);
+            }, leading: Icon(LucideIcons.folderClosed)),
+            MenuFlyoutItem(text: Text(localizations.genericSettings), onPressed: () { GoRouter.of(context).push(SettingsScreen.defaultRoute); }, leading: Icon(LucideIcons.settings), trailing: shortcut("Ctrl+S")),
+            MenuFlyoutItem(text: Text(localizations.actionRestoreLiveView), onPressed: () { getIt<LiveViewManager>().restoreLiveView(); }, leading: Icon(LucideIcons.rotateCcw), trailing: shortcut("Ctrl+R")),
+            const MenuFlyoutSeparator(),
+            MenuFlyoutItem(text: Text(localizations.actionsExit), onPressed: getIt<WindowManager>().close,)
+          ]),
+          MenuBarItem(title: localizations.genericView, items: [
+            MenuFlyoutItem(text: Text(localizations.genericFullScreen), onPressed: () { getIt<WindowManager>().toggleFullscreen(); }, leading: Icon(LucideIcons.expand), trailing: shortcut("Ctrl+F/Alt+Enter")),
+            const MenuFlyoutSeparator(),
+            MenuFlyoutItem(text: Text(localizations.screensStart), onPressed: () { router.go(StartScreen.defaultRoute); }, leading: Icon(LucideIcons.play), trailing: shortcut("Ctrl+H")),
+            MenuFlyoutItem(text: Text(localizations.screensGallery), onPressed: () { router.go(GalleryScreen.defaultRoute); }, leading: Icon(LucideIcons.images)),
+            MenuFlyoutItem(text: Text(localizations.screensManualCollage), onPressed: () { router.go(ManualCollageScreen.defaultRoute); }, leading: Icon(LucideIcons.layoutDashboard), trailing: shortcut("Ctrl+M")),
+          ]),
+          MenuBarItem(title: localizations.genericHelp, items: [
+            MenuFlyoutItem(text: Text(localizations.genericDocumentation), onPressed: () { launchUrl(Uri.parse("https://momentobooth.github.io/momentobooth/")); }, leading: Icon(LucideIcons.book)),
+            // TODO go to about screen in settings
+            MenuFlyoutItem(text: Text(localizations.genericAbout), onPressed: () { GoRouter.of(context).push(SettingsScreen.defaultRoute); }, leading: Icon(LucideIcons.info)),
+          ]),
+        ],
+      ),
+    );
+  }
+
+}

--- a/lib/views/photo_booth_screen/screens/capture_screen/capture_screen_view_model.dart
+++ b/lib/views/photo_booth_screen/screens/capture_screen/capture_screen_view_model.dart
@@ -12,6 +12,7 @@ import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/live_view_manager.dart';
 import 'package:momento_booth/managers/mqtt_manager.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
+import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
 import 'package:momento_booth/models/capture_state.dart';
@@ -127,7 +128,7 @@ abstract class CaptureScreenViewModelBase extends ScreenViewModelBase with Store
       final image = await capturer.captureAndGetPhoto();
       getIt<StatsManager>().addCapturedPhoto();
       getIt<PhotosManager>().photos.add(image);
-      if (getIt<SettingsManager>().settings.singlePhotoIsCollage) {
+      if (getIt<ProjectManager>().settings.singlePhotoIsCollage) {
         await captureCollage();
       } else {
         getIt<PhotosManager>().outputImage = image.data;

--- a/lib/views/photo_booth_screen/screens/capture_screen/capture_screen_view_model.dart
+++ b/lib/views/photo_booth_screen/screens/capture_screen/capture_screen_view_model.dart
@@ -109,8 +109,6 @@ abstract class CaptureScreenViewModelBase extends ScreenViewModelBase with Store
     getIt<MqttManager>().publishCaptureState(CaptureState.countdown);
   }
 
-  String get outputFolder => getIt<SettingsManager>().settings.output.localFolder;
-
   Future<void> onCounterFinished() async {
     showFlash = true;
     showCounter = false;

--- a/lib/views/photo_booth_screen/screens/collage_maker_screen/collage_maker_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/collage_maker_screen/collage_maker_screen_controller.dart
@@ -1,3 +1,4 @@
+
 import 'package:flutter/widgets.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
@@ -29,8 +30,6 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
     }
     captureCollage();
   }
-
-  String get outputFolder => getIt<SettingsManager>().settings.output.localFolder;
 
   DateTime? latestCapture;
 

--- a/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_controller.dart
@@ -9,6 +9,7 @@ import 'package:momento_booth/views/base/screen_controller_base.dart';
 import 'package:momento_booth/views/components/dialogs/find_face_dialog.dart';
 import 'package:momento_booth/views/photo_booth_screen/screens/gallery_screen/gallery_screen_view_model.dart';
 import 'package:momento_booth/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen.dart';
+import 'package:momento_booth/views/photo_booth_screen/screens/start_screen/start_screen.dart';
 import 'package:path/path.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
@@ -28,7 +29,11 @@ class GalleryScreenController extends ScreenControllerBase<GalleryScreenViewMode
   }
 
   void onPressedBack() {
-    router.pop();
+    if (router.canPop()) {
+      router.pop();
+    } else {
+      router.go(StartScreen.defaultRoute);
+    }
   }
 
   Future<void> filterWithFaces() async {

--- a/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_view.dart
+++ b/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_view.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:collection/collection.dart';
 import 'package:draggable_scrollbar/draggable_scrollbar.dart';
+import 'package:fluent_ui/fluent_ui.dart' show FluentTheme;
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
@@ -199,7 +200,18 @@ class FilterChoice extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SegmentedButton(
-      style: ButtonStyle(foregroundColor: WidgetStateProperty.all(Colors.white)),
+      style: ButtonStyle(
+        backgroundColor: WidgetStateProperty.resolveWith<Color>(
+          (states) {
+              if (states.contains(WidgetState.selected)) {
+                return FluentTheme.of(context).accentColor;
+              }
+              return Colors.transparent;
+            },
+        ),
+        iconColor: WidgetStateProperty.all(Colors.white),
+        foregroundColor: WidgetStateProperty.all(Colors.white)
+      ),
       showSelectedIcon: false,
       segments: const [
         ButtonSegment(

--- a/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_view_model.dart
+++ b/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_view_model.dart
@@ -6,6 +6,7 @@ import 'package:intl/intl.dart';
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
+import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/models/gallery_group.dart';
 import 'package:momento_booth/models/gallery_image.dart';
@@ -30,7 +31,7 @@ abstract class GalleryScreenViewModelBase extends ScreenViewModelBase with Store
 
   final DateFormat formatter = DateFormat("MMM dd – HH:mm");
 
-  Directory get outputDir => Directory(getIt<SettingsManager>().settings.output.localFolder);
+  Directory get outputDir => getIt<ProjectManager>().getOutputDir();
   String get baseName => getIt<PhotosManager>().baseName;
 
   bool get isFaceRecognitionEnabled => getIt<SettingsManager>().settings.faceRecognition.enable;

--- a/lib/views/photo_booth_screen/screens/manual_collage_screen/manual_collage_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/manual_collage_screen/manual_collage_screen_controller.dart
@@ -97,8 +97,6 @@ class ManualCollageScreenController extends ScreenControllerBase<ManualCollageSc
     }
   }
 
-  String get outputFolder => getIt<SettingsManager>().settings.output.localFolder;
-
   Future<void> captureCollage() async {
     if (viewModel.numSelected < 1 || viewModel.isSaving) return;
 

--- a/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_view_model.dart
+++ b/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_view_model.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/main.dart';
+import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
 import 'package:momento_booth/models/gallery_image.dart';
@@ -26,7 +27,7 @@ abstract class PhotoDetailsScreenViewModelBase extends ScreenViewModelBase with 
     required this.photoId,
   });
 
-  Directory get outputDir => Directory(getIt<SettingsManager>().settings.output.localFolder);
+  Directory get outputDir => getIt<ProjectManager>().getOutputDir();
   File? get file => File(path.join(outputDir.path, photoId));
   Future<List<MomentoBoothExifTag>> get metadata async => await getMomentoBoothExifTagsFromFile(imageFilePath: file!.path);
   Future<GalleryImage> get galleryImage async => GalleryImage(file: file!, exifTags: await metadata);

--- a/lib/views/photo_booth_screen/screens/share_screen/share_screen_view_model.dart
+++ b/lib/views/photo_booth_screen/screens/share_screen/share_screen_view_model.dart
@@ -7,6 +7,7 @@ import 'package:intl/intl.dart';
 import 'package:mobx/mobx.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
+import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
 import 'package:momento_booth/src/rust/api/ffsend.dart';
@@ -23,7 +24,7 @@ abstract class ShareScreenViewModelBase extends ScreenViewModelBase with Store {
     required super.contextAccessor,
   });
 
-  bool get displayConfetti => getIt<SettingsManager>().settings.ui.displayConfetti;
+  bool get displayConfetti => getIt<ProjectManager>().settings.displayConfetti;
   late final ConfettiController confettiController = ConfettiController(duration: const Duration(milliseconds: 100))..play();
 
   Uint8List get outputImage => getIt<PhotosManager>().outputImage!;
@@ -47,7 +48,7 @@ abstract class ShareScreenViewModelBase extends ScreenViewModelBase with Store {
   File? _file;
 
   List<Color>? getColors() {
-    if (!getIt<SettingsManager>().settings.ui.customColorConfetti) return null;
+    if (!getIt<ProjectManager>().settings.customColorConfetti) return null;
     final theme = FluentTheme.of(contextAccessor.buildContext);
     final accentColor = HSLColor.fromColor(theme.accentColor);
     final List<double> lValues = [0.2, 0.4, 0.5, 0.7, 0.9, 1];

--- a/lib/views/photo_booth_screen/screens/start_screen/start_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/start_screen/start_screen_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/widgets.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/views/base/printer_status_dialog_mixin.dart';
@@ -17,7 +18,7 @@ class StartScreenController extends ScreenControllerBase<StartScreenViewModel> w
     required super.viewModel,
     required super.contextAccessor,
   }) {
-    Timer.run(noProjectOpenedDialog);
+    WidgetsBinding.instance.addPostFrameCallback((_) => noProjectOpenedDialog());
   }
 
   Future<void> noProjectOpenedDialog() async {

--- a/lib/views/photo_booth_screen/screens/start_screen/start_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/start_screen/start_screen_controller.dart
@@ -1,5 +1,10 @@
+import 'dart:async';
+
+import 'package:momento_booth/main.dart';
+import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/views/base/printer_status_dialog_mixin.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
+import 'package:momento_booth/views/components/dialogs/no_project_open_dialog.dart';
 import 'package:momento_booth/views/photo_booth_screen/screens/choose_capture_mode_screen/choose_capture_mode_screen.dart';
 import 'package:momento_booth/views/photo_booth_screen/screens/gallery_screen/gallery_screen.dart';
 import 'package:momento_booth/views/photo_booth_screen/screens/start_screen/start_screen_view_model.dart';
@@ -11,7 +16,17 @@ class StartScreenController extends ScreenControllerBase<StartScreenViewModel> w
   StartScreenController({
     required super.viewModel,
     required super.contextAccessor,
-  });
+  }) {
+    Timer.run(noProjectOpenedDialog);
+  }
+
+  Future<void> noProjectOpenedDialog() async {
+    if (!getIt<ProjectManager>().isOpen) {
+      await showUserDialog(
+        dialog: NoProjectOpenDialog(onOpened: () { navigator.pop(); },), barrierDismissible: false,
+      );
+    }
+  }
 
   // User interaction methods
 

--- a/lib/views/photo_booth_screen/screens/start_screen/start_screen_view.dart
+++ b/lib/views/photo_booth_screen/screens/start_screen/start_screen_view.dart
@@ -1,5 +1,6 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:fluent_ui/fluent_ui.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:momento_booth/views/base/screen_view_base.dart';
 import 'package:momento_booth/views/components/animations/lottie_animation_wrapper.dart';
@@ -55,10 +56,13 @@ class StartScreenView extends ScreenViewBase<StartScreenViewModel, StartScreenCo
         Expanded(
           flex: 2,
           child: Center(
-            child: AutoSizeText(
-              viewModel.touchToStartText,
-              style: theme.titleStyle,
-              textAlign: TextAlign.center,
+            child: Observer(
+              builder: (context) =>
+                AutoSizeText(
+                  viewModel.touchToStartText,
+                  style: theme.titleStyle,
+                  textAlign: TextAlign.center,
+                )
             ),
           ),
         ),

--- a/lib/views/photo_booth_screen/screens/start_screen/start_screen_view_model.dart
+++ b/lib/views/photo_booth_screen/screens/start_screen/start_screen_view_model.dart
@@ -2,6 +2,7 @@ import 'package:mobx/mobx.dart';
 import 'package:momento_booth/extensions/string_extension.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
+import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/views/base/screen_view_model_base.dart';
@@ -17,7 +18,7 @@ abstract class StartScreenViewModelBase extends ScreenViewModelBase with Store {
 
   @computed
   String get touchToStartText =>
-      getIt<SettingsManager>().settings.ui.introScreenTouchToStartOverrideText.nullIfEmpty ??
+      getIt<ProjectManager>().settings.introScreenTouchToStartOverrideText.nullIfEmpty ??
       localizations.startScreenTouchToStartButton;
 
   StartScreenViewModelBase({required super.contextAccessor}) {

--- a/lib/views/settings_screen/pages/settings_screen_view.general.dart
+++ b/lib/views/settings_screen/pages/settings_screen_view.general.dart
@@ -11,13 +11,6 @@ Widget _getGeneralSettings(SettingsScreenViewModel viewModel, SettingsScreenCont
         value: () => viewModel.captureDelaySecondsSetting,
         onFinishedEditing: controller.onCaptureDelaySecondsChanged,
       ),
-      BooleanInputCard(
-        icon: LucideIcons.image,
-        title: "Treat single photo as collage",
-        subtitle: "If enabled, a single picture will be processed as if it were a collage with 1 photo selected. Else the photo will be used unaltered.",
-        value: () => viewModel.singlePhotoIsCollageSetting,
-        onChanged: controller.onSinglePhotoIsCollageChanged,
-      ),
       const FluentSettingsBlock(
         title: "Hotkeys",
         settings: [

--- a/lib/views/settings_screen/pages/settings_screen_view.general.dart
+++ b/lib/views/settings_screen/pages/settings_screen_view.general.dart
@@ -11,6 +11,13 @@ Widget _getGeneralSettings(SettingsScreenViewModel viewModel, SettingsScreenCont
         value: () => viewModel.captureDelaySecondsSetting,
         onFinishedEditing: controller.onCaptureDelaySecondsChanged,
       ),
+      BooleanInputCard(
+        icon: LucideIcons.folderDot,
+        title: "Load last project on start",
+        subtitle: "When enabled, MomentoBooth will load the last opened project when it starts.",
+        value: () => viewModel.loadLastProjectSetting,
+        onChanged: controller.onLoadLastProjectChanged,
+      ),
       const FluentSettingsBlock(
         title: "Hotkeys",
         settings: [

--- a/lib/views/settings_screen/pages/settings_screen_view.hardware.dart
+++ b/lib/views/settings_screen/pages/settings_screen_view.hardware.dart
@@ -196,18 +196,6 @@ Widget _getPhotoCaptureBlock(SettingsScreenViewModel viewModel, SettingsScreenCo
         }
         return const SizedBox();
       }),
-      // Observer(builder: (_) {
-      //   if (viewModel.captureMethodSetting != CaptureMethod.sonyImagingEdgeDesktop && viewModel.saveCapturesToDiskSetting) {
-      //     return FolderPickerCard(
-      //       icon: LucideIcons.folderInput,
-      //       title: "Capture storage location",
-      //       subtitle: "Location where all captured photos (as retrieved from the capture implementation) will be saved to",
-      //       controller: controller.captureStorageLocationController,
-      //       onChanged: controller.onCaptureStorageLocationChanged,
-      //     );
-      //   }
-      //   return const SizedBox();
-      // }),
     ],
   );
 }

--- a/lib/views/settings_screen/pages/settings_screen_view.hardware.dart
+++ b/lib/views/settings_screen/pages/settings_screen_view.hardware.dart
@@ -196,18 +196,18 @@ Widget _getPhotoCaptureBlock(SettingsScreenViewModel viewModel, SettingsScreenCo
         }
         return const SizedBox();
       }),
-      Observer(builder: (_) {
-        if (viewModel.captureMethodSetting != CaptureMethod.sonyImagingEdgeDesktop && viewModel.saveCapturesToDiskSetting) {
-          return FolderPickerCard(
-            icon: LucideIcons.folderInput,
-            title: "Capture storage location",
-            subtitle: "Location where all captured photos (as retrieved from the capture implementation) will be saved to",
-            controller: controller.captureStorageLocationController,
-            onChanged: controller.onCaptureStorageLocationChanged,
-          );
-        }
-        return const SizedBox();
-      }),
+      // Observer(builder: (_) {
+      //   if (viewModel.captureMethodSetting != CaptureMethod.sonyImagingEdgeDesktop && viewModel.saveCapturesToDiskSetting) {
+      //     return FolderPickerCard(
+      //       icon: LucideIcons.folderInput,
+      //       title: "Capture storage location",
+      //       subtitle: "Location where all captured photos (as retrieved from the capture implementation) will be saved to",
+      //       controller: controller.captureStorageLocationController,
+      //       onChanged: controller.onCaptureStorageLocationChanged,
+      //     );
+      //   }
+      //   return const SizedBox();
+      // }),
     ],
   );
 }

--- a/lib/views/settings_screen/pages/settings_screen_view.output.dart
+++ b/lib/views/settings_screen/pages/settings_screen_view.output.dart
@@ -7,13 +7,13 @@ Widget _getOutputSettings(SettingsScreenViewModel viewModel, SettingsScreenContr
       FluentSettingsBlock(
         title: "Local",
         settings: [
-          FolderPickerCard(
-            icon: LucideIcons.folderInput,
-            title: "Local photo storage location",
-            subtitle: "Location where the output images will be stored",
-            controller: controller.localFolderSettingController,
-            onChanged: controller.onLocalFolderChanged,
-          ),
+          // FolderPickerCard(
+          //   icon: LucideIcons.folderInput,
+          //   title: "Local photo storage location",
+          //   subtitle: "Location where the output images will be stored",
+          //   controller: controller.localFolderSettingController,
+          //   onChanged: controller.onLocalFolderChanged,
+          // ),
         ],
       ),
       FluentSettingsBlock(

--- a/lib/views/settings_screen/pages/settings_screen_view.output.dart
+++ b/lib/views/settings_screen/pages/settings_screen_view.output.dart
@@ -7,13 +7,7 @@ Widget _getOutputSettings(SettingsScreenViewModel viewModel, SettingsScreenContr
       FluentSettingsBlock(
         title: "Local",
         settings: [
-          // FolderPickerCard(
-          //   icon: LucideIcons.folderInput,
-          //   title: "Local photo storage location",
-          //   subtitle: "Location where the output images will be stored",
-          //   controller: controller.localFolderSettingController,
-          //   onChanged: controller.onLocalFolderChanged,
-          // ),
+          Text("Collages are saved to the Output folder of your project.")
         ],
       ),
       FluentSettingsBlock(

--- a/lib/views/settings_screen/pages/settings_screen_view.project.dart
+++ b/lib/views/settings_screen/pages/settings_screen_view.project.dart
@@ -1,6 +1,5 @@
 part of '../settings_screen_view.dart';
 
-// TODO figure out how to define when override happens and when a setting is just not set.
 Widget _getProjectSettings(SettingsScreenViewModel viewModel, SettingsScreenController controller) {
   return SettingsPage(
     title: "Project",
@@ -9,46 +8,55 @@ Widget _getProjectSettings(SettingsScreenViewModel viewModel, SettingsScreenCont
         padding: EdgeInsets.symmetric(vertical: 4.0),
         child: Text("These settings are project-specific and override global behaviour. The settings are saved in your project directory, so the settings are also used when the project is opened on another computer.", style: TextStyle(fontSize: 16)),
       ),
-      FluentSettingsBlock(
-        title: "Project settings",
-        settings: [
-          ColorInputCard(
-            icon: LucideIcons.paintbrushVertical,
-            title: "Primary color",
-            subtitle: "The primary color of the app",
-            value: () => viewModel.primaryColorSetting,
-            onChanged: controller.onPrimaryColorChanged,
-          ),
-          BooleanInputCard(
-            icon: LucideIcons.palette,
-            title: "Colorize confetti to the theme color",
-            subtitle: "If enabled, confetti will will be various shades of the theme color. Else, random colors will be used.",
-            value: () => viewModel.customColorConfettiSetting,
-            onChanged: controller.onCustomColorConfettiChanged,
-          ),
-          TextInputCard(
-            icon: LucideIcons.heading,
-            title: "Alternative 'Touch to start' title text",
-            subtitle: "The override text that will be shown on the Start screen instead of 'Touch to start'. Leave empty to show the default text from the translations data.",
-            controller: controller.introScreenTouchToStartOverrideTextController,
-            onFinishedEditing: controller.onIntroScreenTouchToStartOverrideText,
-          ),
-          NumberInputCard(
-            icon: LucideIcons.ratio,
-            title: "Aspect ratio",
-            subtitle: 'The aspect ratio to which live view and captures are cropped.',
-            value: () => viewModel.liveViewAndCaptureAspectRatioSetting,
-            onFinishedEditing: controller.onLiveViewAndCaptureAspectRatioChanged,
-            smallChange: 0.1,
-          ),
-          BooleanInputCard(
-            icon: LucideIcons.image,
-            title: "Treat single photo as collage",
-            subtitle: "If enabled, a single picture will be processed as if it were a collage with 1 photo selected. Else the photo will be used unaltered.",
-            value: () => viewModel.singlePhotoIsCollageSetting,
-            onChanged: controller.onSinglePhotoIsCollageChanged,
-          ),
-        ]
+      Builder(
+        builder: (context) {
+          if (!getIt<ProjectManager>().isOpen) {
+            return Padding(
+              padding: const EdgeInsets.only(top: 16.0),
+              child: InfoBar(title: Text("Project settings can only be viewed and modified if a project is loaded."), severity: InfoBarSeverity.warning,),
+            );
+          }
+          return FluentSettingsBlock(
+            title: "Project settings",
+            settings: [
+              ColorInputCard(
+                icon: LucideIcons.paintbrushVertical,
+                title: "Primary color",
+                subtitle: "The primary color of the app",
+                value: () => viewModel.primaryColorSetting,
+                onChanged: controller.onPrimaryColorChanged,
+              ),
+              BooleanInputCard(
+                icon: LucideIcons.partyPopper,
+                title: "Display confetti 🎉",
+                subtitle: "If enabled, confetti will shower the share screen!",
+                value: () => viewModel.displayConfettiSetting,
+                onChanged: controller.onDisplayConfettiChanged,
+              ),
+              BooleanInputCard(
+                icon: LucideIcons.palette,
+                title: "Colorize confetti to the theme color",
+                subtitle: "If enabled, confetti will will be various shades of the theme color. Else, random colors will be used.",
+                value: () => viewModel.customColorConfettiSetting,
+                onChanged: controller.onCustomColorConfettiChanged,
+              ),
+              TextInputCard(
+                icon: LucideIcons.heading,
+                title: "Alternative 'Touch to start' title text",
+                subtitle: "The override text that will be shown on the Start screen instead of 'Touch to start'. Leave empty to show the default text from the translations data.",
+                controller: controller.introScreenTouchToStartOverrideTextController,
+                onFinishedEditing: controller.onIntroScreenTouchToStartOverrideText,
+              ),
+              BooleanInputCard(
+                icon: LucideIcons.image,
+                title: "Treat single photo as collage",
+                subtitle: "If enabled, a single picture will be processed as if it were a collage with 1 photo selected. Else the photo will be used unaltered.",
+                value: () => viewModel.singlePhotoIsCollageSetting,
+                onChanged: controller.onSinglePhotoIsCollageChanged,
+              ),
+            ]
+          );
+        }
       ),
     ],
   );

--- a/lib/views/settings_screen/pages/settings_screen_view.project.dart
+++ b/lib/views/settings_screen/pages/settings_screen_view.project.dart
@@ -1,0 +1,55 @@
+part of '../settings_screen_view.dart';
+
+// TODO figure out how to define when override happens and when a setting is just not set.
+Widget _getProjectSettings(SettingsScreenViewModel viewModel, SettingsScreenController controller) {
+  return SettingsPage(
+    title: "Project",
+    blocks: [
+      Padding(
+        padding: EdgeInsets.symmetric(vertical: 4.0),
+        child: Text("These settings are project-specific and override global behaviour. The settings are saved in your project directory, so the settings are also used when the project is opened on another computer.", style: TextStyle(fontSize: 16)),
+      ),
+      FluentSettingsBlock(
+        title: "Project settings",
+        settings: [
+          ColorInputCard(
+            icon: LucideIcons.paintbrushVertical,
+            title: "Primary color",
+            subtitle: "The primary color of the app",
+            value: () => viewModel.primaryColorSetting,
+            onChanged: controller.onPrimaryColorChanged,
+          ),
+          BooleanInputCard(
+            icon: LucideIcons.palette,
+            title: "Colorize confetti to the theme color",
+            subtitle: "If enabled, confetti will will be various shades of the theme color. Else, random colors will be used.",
+            value: () => viewModel.customColorConfettiSetting,
+            onChanged: controller.onCustomColorConfettiChanged,
+          ),
+          TextInputCard(
+            icon: LucideIcons.heading,
+            title: "Alternative 'Touch to start' title text",
+            subtitle: "The override text that will be shown on the Start screen instead of 'Touch to start'. Leave empty to show the default text from the translations data.",
+            controller: controller.introScreenTouchToStartOverrideTextController,
+            onFinishedEditing: controller.onIntroScreenTouchToStartOverrideText,
+          ),
+          NumberInputCard(
+            icon: LucideIcons.ratio,
+            title: "Aspect ratio",
+            subtitle: 'The aspect ratio to which live view and captures are cropped.',
+            value: () => viewModel.liveViewAndCaptureAspectRatioSetting,
+            onFinishedEditing: controller.onLiveViewAndCaptureAspectRatioChanged,
+            smallChange: 0.1,
+          ),
+          BooleanInputCard(
+            icon: LucideIcons.image,
+            title: "Treat single photo as collage",
+            subtitle: "If enabled, a single picture will be processed as if it were a collage with 1 photo selected. Else the photo will be used unaltered.",
+            value: () => viewModel.singlePhotoIsCollageSetting,
+            onChanged: controller.onSinglePhotoIsCollageChanged,
+          ),
+        ]
+      ),
+    ],
+  );
+}

--- a/lib/views/settings_screen/pages/settings_screen_view.templating.dart
+++ b/lib/views/settings_screen/pages/settings_screen_view.templating.dart
@@ -104,13 +104,6 @@ Widget _getTemplateSettings(SettingsScreenViewModel viewModel, SettingsScreenCon
   return FluentSettingsBlock(
     title: "Creative",
     settings: [
-      FolderPickerCard(
-        icon: LucideIcons.folder,
-        title: "Collage background templates location",
-        subtitle: "Location to look for template files",
-        controller: controller.templatesFolderSettingController,
-        onChanged: controller.onTemplatesFolderChanged,
-      ),
       NumberInputCard(
         icon: LucideIcons.ratio,
         title: "Collage aspect ratio",

--- a/lib/views/settings_screen/pages/settings_screen_view.ui.dart
+++ b/lib/views/settings_screen/pages/settings_screen_view.ui.dart
@@ -29,6 +29,7 @@ Widget _getUiSettings(SettingsScreenViewModel viewModel, SettingsScreenControlle
       FluentSettingsBlock(
         title: "Animations",
         settings: [
+          // FIXME: Add functionality
           // BooleanInputCard(
           //   icon: LucideIcons.partyPopper,
           //   title: "Disable confetti 🚫🎉",

--- a/lib/views/settings_screen/pages/settings_screen_view.ui.dart
+++ b/lib/views/settings_screen/pages/settings_screen_view.ui.dart
@@ -31,10 +31,10 @@ Widget _getUiSettings(SettingsScreenViewModel viewModel, SettingsScreenControlle
         settings: [
           // BooleanInputCard(
           //   icon: LucideIcons.partyPopper,
-          //   title: "Display confetti 🎉",
-          //   subtitle: "If enabled, confetti will shower the share screen!",
-          //   value: () => viewModel.displayConfettiSetting,
-          //   onChanged: controller.onDisplayConfettiChanged,
+          //   title: "Disable confetti 🚫🎉",
+          //   subtitle: "If enabled, confetti will be disabled on the share screen, even if enabled by the project.",
+          //   value: () => viewModel.disableConfettiSetting,
+          //   onChanged: controller.onDisableConfettiChanged,
           // ),
           ComboBoxCard<ScreenTransitionAnimation>(
             icon: LucideIcons.arrowRightLeft,

--- a/lib/views/settings_screen/pages/settings_screen_view.ui.dart
+++ b/lib/views/settings_screen/pages/settings_screen_view.ui.dart
@@ -4,20 +4,6 @@ Widget _getUiSettings(SettingsScreenViewModel viewModel, SettingsScreenControlle
   return SettingsPage(
     title: "User interface",
     blocks: [
-      ColorInputCard(
-        icon: LucideIcons.paintbrushVertical,
-        title: "Primary color",
-        subtitle: "The primary color of the app",
-        value: () => viewModel.primaryColorSetting,
-        onChanged: controller.onPrimaryColorChanged,
-      ),
-      TextInputCard(
-        icon: LucideIcons.heading,
-        title: "Alternative 'Touch to start' title text",
-        subtitle: "The override text that will be shown on the Start screen instead of 'Touch to start'. Leave empty to show the default text from the translations data.",
-        controller: controller.introScreenTouchToStartOverrideTextController,
-        onFinishedEditing: controller.onIntroScreenTouchToStartOverrideText,
-      ),
       NumberInputCard(
         icon: LucideIcons.timer,
         title: "Return to home timeout",
@@ -43,20 +29,13 @@ Widget _getUiSettings(SettingsScreenViewModel viewModel, SettingsScreenControlle
       FluentSettingsBlock(
         title: "Animations",
         settings: [
-          BooleanInputCard(
-            icon: LucideIcons.partyPopper,
-            title: "Display confetti 🎉",
-            subtitle: "If enabled, confetti will shower the share screen!",
-            value: () => viewModel.displayConfettiSetting,
-            onChanged: controller.onDisplayConfettiChanged,
-          ),
-          BooleanInputCard(
-            icon: LucideIcons.palette,
-            title: "Colorize confetti to the theme color",
-            subtitle: "If enabled, confetti will will be various shades of the theme color. Else, random colors will be used.",
-            value: () => viewModel.customColorConfettiSetting,
-            onChanged: controller.onCustomColorConfettiChanged,
-          ),
+          // BooleanInputCard(
+          //   icon: LucideIcons.partyPopper,
+          //   title: "Display confetti 🎉",
+          //   subtitle: "If enabled, confetti will shower the share screen!",
+          //   value: () => viewModel.displayConfettiSetting,
+          //   onChanged: controller.onDisplayConfettiChanged,
+          // ),
           ComboBoxCard<ScreenTransitionAnimation>(
             icon: LucideIcons.arrowRightLeft,
             title: "Screen transition animation",

--- a/lib/views/settings_screen/settings_screen_controller.dart
+++ b/lib/views/settings_screen/settings_screen_controller.dart
@@ -106,6 +106,12 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
     }
   }
 
+  void onLoadLastProjectChanged(bool? loadLastProject) {
+    if (loadLastProject != null) {
+      viewModel.updateSettings((settings) => settings.copyWith(loadLastProject: loadLastProject));
+    }
+  }
+
   void onCollageAspectRatioChanged(double? collageAspectRatio) {
     if (collageAspectRatio != null) {
       viewModel.updateSettings((settings) => settings.copyWith(collageAspectRatio: collageAspectRatio));

--- a/lib/views/settings_screen/settings_screen_controller.dart
+++ b/lib/views/settings_screen/settings_screen_controller.dart
@@ -120,7 +120,7 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
 
   void onSinglePhotoIsCollageChanged(bool? singlePhotoIsCollage) {
     if (singlePhotoIsCollage != null) {
-      viewModel.updateSettings((settings) => settings.copyWith(singlePhotoIsCollage: singlePhotoIsCollage));
+      viewModel.updateProjectSettings((settings) => settings.copyWith(singlePhotoIsCollage: singlePhotoIsCollage));
     }
   }
 
@@ -444,7 +444,7 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
 
   void onPrimaryColorChanged(Color? primaryColor) {
     if (primaryColor != null) {
-      viewModel.updateSettings((settings) => settings.copyWith.ui(primaryColor: primaryColor));
+      viewModel.updateProjectSettings((settings) => settings.copyWith(primaryColor: primaryColor));
     }
   }
 
@@ -456,19 +456,19 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
 
   void onIntroScreenTouchToStartOverrideText(String? introScreenTouchToStartOverrideText) {
     if (introScreenTouchToStartOverrideText != null) {
-      viewModel.updateSettings((settings) => settings.copyWith.ui(introScreenTouchToStartOverrideText: introScreenTouchToStartOverrideText));
+      viewModel.updateProjectSettings((settings) => settings.copyWith(introScreenTouchToStartOverrideText: introScreenTouchToStartOverrideText));
     }
   }
 
   void onDisplayConfettiChanged(bool? displayConfetti) {
     if (displayConfetti != null) {
-      viewModel.updateSettings((settings) => settings.copyWith.ui(displayConfetti: displayConfetti));
+      viewModel.updateProjectSettings((settings) => settings.copyWith(displayConfetti: displayConfetti));
     }
   }
 
   void onCustomColorConfettiChanged(bool? customColorConfetti) {
     if (customColorConfetti != null) {
-      viewModel.updateSettings((settings) => settings.copyWith.ui(customColorConfetti: customColorConfetti));
+      viewModel.updateProjectSettings((settings) => settings.copyWith(customColorConfetti: customColorConfetti));
     }
   }
 

--- a/lib/views/settings_screen/settings_screen_view.dart
+++ b/lib/views/settings_screen/settings_screen_view.dart
@@ -33,6 +33,7 @@ import 'package:talker_flutter/talker_flutter.dart';
 part 'pages/settings_screen_view.about.dart';
 part 'pages/settings_screen_view.debug.dart';
 part 'pages/settings_screen_view.face_recognition.dart';
+part 'pages/settings_screen_view.project.dart';
 part 'pages/settings_screen_view.general.dart';
 part 'pages/settings_screen_view.hardware.dart';
 part 'pages/settings_screen_view.mqtt_integration.dart';
@@ -60,6 +61,13 @@ class SettingsScreenView extends ScreenViewBase<SettingsScreenViewModel, Setting
             onChanged: controller.onNavigationPaneIndexChanged,
             items: [
               PaneItemSeparator(color: Colors.transparent),
+              PaneItemHeader(header: const Text('Project')),
+              PaneItem(
+                icon: const Icon(LucideIcons.folderCog),
+                title: const Text("Project"),
+                body: Builder(builder: (_) => _getProjectSettings(viewModel, controller)),
+              ),
+              PaneItemHeader(header: const Text('App')),
               PaneItem(
                 icon: const Icon(LucideIcons.settings),
                 title: const Text("General"),

--- a/lib/views/settings_screen/settings_screen_view.dart
+++ b/lib/views/settings_screen/settings_screen_view.dart
@@ -5,6 +5,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/mqtt_manager.dart';
+import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/repositories/secrets/secrets_repository.dart';

--- a/lib/views/settings_screen/settings_screen_view_model.dart
+++ b/lib/views/settings_screen/settings_screen_view_model.dart
@@ -153,6 +153,7 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
 
   // System settings current values
   int get captureDelaySecondsSetting => getIt<SettingsManager>().settings.captureDelaySeconds;
+  bool get loadLastProjectSetting => getIt<SettingsManager>().settings.loadLastProject;
   double get collageAspectRatioSetting => getIt<SettingsManager>().settings.collageAspectRatio;
   double get collagePaddingSetting => getIt<SettingsManager>().settings.collagePadding;
   String get templatesFolderSetting => getIt<SettingsManager>().settings.templatesFolder;

--- a/lib/views/settings_screen/settings_screen_view_model.dart
+++ b/lib/views/settings_screen/settings_screen_view_model.dart
@@ -5,8 +5,10 @@ import 'package:momento_booth/hardware_control/gphoto2_camera.dart';
 import 'package:momento_booth/hardware_control/live_view_streaming/nokhwa_camera.dart';
 import 'package:momento_booth/hardware_control/printing/cups_client.dart';
 import 'package:momento_booth/main.dart';
+import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/models/print_queue_info.dart';
+import 'package:momento_booth/models/project_settings.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/src/rust/utils/ipp_client.dart';
 import 'package:momento_booth/views/base/screen_view_model_base.dart';
@@ -16,6 +18,7 @@ import 'package:printing/printing.dart';
 part 'settings_screen_view_model.g.dart';
 
 typedef UpdateSettingsCallback = Settings Function(Settings settings);
+typedef UpdateProjectSettingsCallback = ProjectSettings Function(ProjectSettings settings);
 
 class SettingsScreenViewModel = SettingsScreenViewModelBase with _$SettingsScreenViewModel;
 
@@ -141,12 +144,17 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
   Future<void> setWebcamList() async => webcams = await NokhwaCamera.getCamerasAsComboBoxItems();
   Future<void> setCameraList() async => gPhoto2Cameras = await GPhoto2Camera.getCamerasAsComboBoxItems();
 
-  // Current values
+  // Project settings current values
+  String get introScreenTouchToStartOverrideTextSetting => getIt<ProjectManager>().settings.introScreenTouchToStartOverrideText;
+  bool get displayConfettiSetting => getIt<ProjectManager>().settings.displayConfetti;
+  bool get customColorConfettiSetting => getIt<ProjectManager>().settings.customColorConfetti;
+  bool get singlePhotoIsCollageSetting => getIt<ProjectManager>().settings.singlePhotoIsCollage;
+  Color get primaryColorSetting => getIt<ProjectManager>().settings.primaryColor;
 
+  // System settings current values
   int get captureDelaySecondsSetting => getIt<SettingsManager>().settings.captureDelaySeconds;
   double get collageAspectRatioSetting => getIt<SettingsManager>().settings.collageAspectRatio;
   double get collagePaddingSetting => getIt<SettingsManager>().settings.collagePadding;
-  bool get singlePhotoIsCollageSetting => getIt<SettingsManager>().settings.singlePhotoIsCollage;
   String get templatesFolderSetting => getIt<SettingsManager>().settings.templatesFolder;
   Rotate get liveViewAndCaptureRotateSetting => getIt<SettingsManager>().settings.hardware.liveViewAndCaptureRotate;
   Flip get liveViewFlipSetting => getIt<SettingsManager>().settings.hardware.liveViewFlip;
@@ -191,11 +199,7 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
   ExportFormat get exportFormat => getIt<SettingsManager>().settings.output.exportFormat;
   int get jpgQuality => getIt<SettingsManager>().settings.output.jpgQuality;
   double get resolutionMultiplier => getIt<SettingsManager>().settings.output.resolutionMultiplier;
-  Color get primaryColorSetting => getIt<SettingsManager>().settings.ui.primaryColor;
   int get returnToHomeTimeoutSeconds => getIt<SettingsManager>().settings.ui.returnToHomeTimeoutSeconds;
-  String get introScreenTouchToStartOverrideTextSetting => getIt<SettingsManager>().settings.ui.introScreenTouchToStartOverrideText;
-  bool get displayConfettiSetting => getIt<SettingsManager>().settings.ui.displayConfetti;
-  bool get customColorConfettiSetting => getIt<SettingsManager>().settings.ui.customColorConfetti;
   bool get enableSfxSetting => getIt<SettingsManager>().settings.ui.enableSfx;
   String get clickSfxFileSetting => getIt<SettingsManager>().settings.ui.clickSfxFile;
   String get shareScreenSfxFileSetting => getIt<SettingsManager>().settings.ui.shareScreenSfxFile;
@@ -243,6 +247,12 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
     Settings currentSettings = getIt<SettingsManager>().settings;
     Settings updatedSettings = updateCallback(currentSettings);
     await getIt<SettingsManager>().updateAndSave(updatedSettings);
+  }
+
+  Future<void> updateProjectSettings(UpdateProjectSettingsCallback updateCallback) async {
+    ProjectSettings currentSettings = getIt<ProjectManager>().settings;
+    ProjectSettings updatedSettings = updateCallback(currentSettings);
+    await getIt<ProjectManager>().updateAndSave(updatedSettings);
   }
 
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -16,6 +16,7 @@ import screen_retriever_macos
 import sentry_flutter
 import share_plus
 import texture_rgba_renderer
+import url_launcher_macos
 import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -30,5 +31,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   SentryFlutterPlugin.register(with: registry.registrar(forPlugin: "SentryFlutterPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   TextureRgbaRendererPlugin.register(with: registry.registrar(forPlugin: "TextureRgbaRendererPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -20,14 +20,16 @@ PODS:
     - FlutterMacOS
   - screen_retriever_macos (0.0.1):
     - FlutterMacOS
-  - Sentry/HybridSDK (8.42.0)
-  - sentry_flutter (8.12.0):
+  - Sentry/HybridSDK (8.44.0)
+  - sentry_flutter (8.13.0):
     - Flutter
     - FlutterMacOS
-    - Sentry/HybridSDK (= 8.42.0)
+    - Sentry/HybridSDK (= 8.44.0)
   - share_plus (0.0.1):
     - FlutterMacOS
   - texture_rgba_renderer (0.0.1):
+    - FlutterMacOS
+  - url_launcher_macos (0.0.1):
     - FlutterMacOS
   - window_manager (0.2.0):
     - FlutterMacOS
@@ -46,6 +48,7 @@ DEPENDENCIES:
   - sentry_flutter (from `Flutter/ephemeral/.symlinks/plugins/sentry_flutter/macos`)
   - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
   - texture_rgba_renderer (from `Flutter/ephemeral/.symlinks/plugins/texture_rgba_renderer/macos`)
+  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
   - window_manager (from `Flutter/ephemeral/.symlinks/plugins/window_manager/macos`)
 
 SPEC REPOS:
@@ -79,25 +82,28 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/share_plus/macos
   texture_rgba_renderer:
     :path: Flutter/ephemeral/.symlinks/plugins/texture_rgba_renderer/macos
+  url_launcher_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
   window_manager:
     :path: Flutter/ephemeral/.symlinks/plugins/window_manager/macos
 
 SPEC CHECKSUMS:
-  audio_session: 48ab6500f7a5e7c64363e206565a5dfe5a0c1441
-  file_selector_macos: 6280b52b459ae6c590af5d78fc35c7267a3c4b31
-  flutter_secure_storage_macos: 7f45e30f838cf2659862a4e4e3ee1c347c2b3b54
+  audio_session: 728ae3823d914f809c485d390274861a24b0904e
+  file_selector_macos: cc3858c981fe6889f364731200d6232dac1d812d
+  flutter_secure_storage_macos: c2754d3483d20bb207bb9e5a14f1b8e771abcdb9
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
-  just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
-  package_info_plus: f0052d280d17aa382b932f399edf32507174e870
-  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  printing: c4cf83c78fd684f9bc318e6aadc18972aa48f617
-  rust_lib_momento_booth: c45ee7d2e5d3020a5512404d9e5a263228366acb
-  screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
-  Sentry: 38ed8bf38eab5812787274bf591e528074c19e02
-  sentry_flutter: a72ca0eb6e78335db7c4ddcddd1b9f6c8ed5b764
-  share_plus: 510bf0af1a42cd602274b4629920c9649c52f4cc
-  texture_rgba_renderer: 6661f577ea5d4990e964c7e3840e544ac798e6da
-  window_manager: 1d01fa7ac65a6e6f83b965471b1a7fdd3f06166c
+  just_audio: a42c63806f16995daf5b219ae1d679deb76e6a79
+  package_info_plus: 12f1c5c2cfe8727ca46cbd0b26677728972d9a5b
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  printing: 1dd6a1fce2209ec240698e2439a4adbb9b427637
+  rust_lib_momento_booth: d43a01b1d47afc3530b2f17956170b4256c0b166
+  screen_retriever_macos: 776e0fa5d42c6163d2bf772d22478df4b302b161
+  Sentry: 0f9bc9adfc0b960e7f3bb5ec67e9a3d8193f3bdb
+  sentry_flutter: c4c3e7feec83e061daf829f6f9359efefab00d87
+  share_plus: 1fa619de8392a4398bfaf176d441853922614e89
+  texture_rgba_renderer: cbed959a3c127122194a364e14b8577bd62dc8f2
+  url_launcher_macos: c82c93949963e55b228a30115bd219499a6fe404
+  window_manager: 3a1844359a6295ab1e47659b1a777e36773cd6e8
 
 PODFILE CHECKSUM: 3d7cd7f90b4de5948ed6e76869b40159643b2f0c
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -63,7 +63,7 @@ packages:
     source: hosted
     version: "4.0.2"
   args:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: args
       sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1440,6 +1440,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.1"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "6fc2f56536ee873eeb867ad176ae15f304ccccc357848b351f6f0d8d4a40d193"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.14"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "16a513b6c12bb419304e72ea0ae2ab4fed569920d1c7cb850263fe3acc824626"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -1448,6 +1472,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "17ba2000b847f334f16626a574c702b196723af2a289e7a93ffcb79acff855c2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
   url_launcher_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -93,6 +93,7 @@ dependencies:
   draggable_scrollbar:
     git: https://github.com/momentobooth/flutter-draggable-scrollbar
   csslib: 1.0.2
+  args: ^2.6.0
 
 dev_dependencies:
   # UI

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -94,6 +94,7 @@ dependencies:
     git: https://github.com/momentobooth/flutter-draggable-scrollbar
   csslib: 1.0.2
   args: ^2.6.0
+  url_launcher: ^6.3.1
 
 dev_dependencies:
   # UI


### PR DESCRIPTION
At first, there were three distinct settings, in different places, for
- The capture storage location
- The collage output
- The templates

This caused a lot of hassle when trying to prepare a set-up for a new event. All paths had to be changed, or the results from the previous event copied and renamed to avoid updating the setting.

This PR changes the central workflow of MomentoBooth to be **project-based**. A project is a directory that contains a fixed structure of sub-directories for captures (`Input`), templates (`Templates`), and collage outputs (`Output`). As such, all paths are directly related to the project folder and when opening the project folder, no other settings need to be changed.

To exploit the project workflow further, some settings have been converted/migrated to **project settings**, which are stored in the project folder as well. Then, when a project is loaded, the defined project settings are automatically applied as well. This allows for easy customization of the interface per event.

Moreover, this PR adds a **menubar** to the UI with e.g. entries to open settings, recent projects, enter fullscreen, navigate, open documentation, etc. Short cuts are displayed next to the entry titles. The menubar is only visible in windowed mode and hidden in fullscreen mode.

Finally, basic **command line argument support** has been added. For now, support is provided for `-o/--open` to open a project directory and `-f/--fullscreen` which is self-explanatory.