### PR TITLE
Fix minor pipelines and build issues

### DIFF
--- a/.github/workflows/pr-ci-app-linux-appimage-x64.yml
+++ b/.github/workflows/pr-ci-app-linux-appimage-x64.yml
@@ -28,7 +28,7 @@ jobs:
         submodules: 'true'
 
     - name: Install apt packages
-      run: sudo apt update && sudo apt install build-essential git clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev llvm libfuse2 libgphoto2-dev libdigest-sha-perl libgexiv2-dev libsecret-1-dev libcurl4-openssl-dev libusb-1.0-0-dev
+      run: sudo apt update && sudo apt install build-essential git clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev llvm libfuse2 libgphoto2-dev libdigest-sha-perl libgexiv2-dev libsecret-1-dev libcurl4-openssl-dev libusb-1.0-0-dev libmimalloc-dev libmimalloc2.0
 
     - name: Detect Flutter Version
       uses: kuhnroyal/flutter-fvm-config-action@v3

--- a/.github/workflows/pr-ci-app-macos-arm64.yml
+++ b/.github/workflows/pr-ci-app-macos-arm64.yml
@@ -79,7 +79,8 @@ jobs:
       uses: Swatinem/rust-cache@v2
       with:
         workspaces: |
-          rust -> ../build/macos/Build/Intermediates.noindex/Pods.build/Release/rust_lib_momento_booth.build
+          rust -> ../build/macos/Build/Intermediates.noindex/Pods.build/Release/rust_lib_momento_booth.build/aarch64-apple-darwin
+          rust -> ../build/macos/Build/Intermediates.noindex/Pods.build/Release/rust_lib_momento_booth.build/x86_64-apple-darwin
           rust -> target
       
     - name: Setup sccache-cache

--- a/.github/workflows/pr-ci-app-win-x64.yml
+++ b/.github/workflows/pr-ci-app-win-x64.yml
@@ -27,19 +27,12 @@ jobs:
       with:
         submodules: 'true'
 
-    # Inspired by: https://github.com/astral-sh/uv/blob/main/.github/workflows/ci.yml
-    - name: Create Dev Drive
+    - name: Setup D drive for builds and caches
       run: |
-        $Volume = New-VHD -Path D:/mb_dev_drive.vhdx -SizeBytes 20GB |
-                  Mount-VHD -Passthru |
-                  Initialize-Disk -Passthru |
-                  New-Partition -AssignDriveLetter -UseMaximumSize |
-                  Format-Volume -FileSystem NTFS -Confirm:$false -Force
-        Write-Output $Volume
-        Write-Output "DEV_DRIVE=$($Volume.DriveLetter):" >> $env:GITHUB_ENV
-        Write-Output "CARGO_HOME=$($Volume.DriveLetter):\.cargo" >> $env:GITHUB_ENV
-        Write-Output "RUSTUP_HOME=$($Volume.DriveLetter):\.rustup" >> $env:GITHUB_ENV
-        Write-Output "SCCACHE_DIR=$($Volume.DriveLetter):\.sccache-cache" >> $env:GITHUB_ENV
+        Write-Output "DEV_DRIVE=D:" >> $env:GITHUB_ENV
+        Write-Output "CARGO_HOME=D:\.cargo" >> $env:GITHUB_ENV
+        Write-Output "RUSTUP_HOME=D:\.rustup" >> $env:GITHUB_ENV
+        Write-Output "SCCACHE_DIR=D:\.sccache-cache" >> $env:GITHUB_ENV
 
     - name: Copy Git Repo to Dev Drive
       run: |

--- a/.github/workflows/pr-ci-app-win-x64.yml
+++ b/.github/workflows/pr-ci-app-win-x64.yml
@@ -212,6 +212,13 @@ jobs:
       run: |
         &"${Env:ProgramFiles(x86)}/Inno Setup 6/iscc.exe" "${{ env.DEV_DRIVE }}/momentobooth/windows/installer/installer.iss"
 
+    - name: Upload libgphoto2 package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: MSYS2 libgphoto2 package
+        path: ${{ env.DEV_DRIVE }}/MINGW-packages/mingw-w64-libgphoto2/mingw-w64-clang-x86_64-libgphoto2-*-any.pkg.tar.zst
+        compression-level: 0
+
     - name: Upload zip artifact
       uses: actions/upload-artifact@v4
       with:
@@ -224,3 +231,4 @@ jobs:
       with:
         name: Windows x64 (installer)
         path: ${{ env.DEV_DRIVE }}/momentobooth/windows/installer/installer.exe
+        compression-level: 0

--- a/.github/workflows/release-linux-appimage-x64.yml
+++ b/.github/workflows/release-linux-appimage-x64.yml
@@ -27,7 +27,7 @@ jobs:
         submodules: 'true'
 
     - name: Install apt packages
-      run: sudo apt update && sudo apt install build-essential git clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev llvm libfuse2 libgphoto2-dev libdigest-sha-perl libgexiv2-dev libsecret-1-dev libcurl4-openssl-dev libusb-1.0-0-dev
+      run: sudo apt update && sudo apt install build-essential git clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev llvm libfuse2 libgphoto2-dev libdigest-sha-perl libgexiv2-dev libsecret-1-dev libcurl4-openssl-dev libusb-1.0-0-dev libmimalloc-dev libmimalloc2.0
 
     - name: Detect Flutter Version
       uses: kuhnroyal/flutter-fvm-config-action@v3

--- a/.github/workflows/release-macos-arm64.yml
+++ b/.github/workflows/release-macos-arm64.yml
@@ -73,7 +73,8 @@ jobs:
       uses: Swatinem/rust-cache@v2
       with:
         workspaces: |
-          rust -> ../build/macos/Build/Intermediates.noindex/Pods.build/Release/rust_lib_momento_booth.build
+          rust -> ../build/macos/Build/Intermediates.noindex/Pods.build/Release/rust_lib_momento_booth.build/aarch64-apple-darwin
+          rust -> ../build/macos/Build/Intermediates.noindex/Pods.build/Release/rust_lib_momento_booth.build/x86_64-apple-darwin
           rust -> target
       
     - name: Setup sccache-cache

--- a/.github/workflows/release-win-x64.yml
+++ b/.github/workflows/release-win-x64.yml
@@ -26,19 +26,12 @@ jobs:
       with:
         submodules: 'true'
 
-    # Inspired by: https://github.com/astral-sh/uv/blob/main/.github/workflows/ci.yml
-    - name: Create Dev Drive using ReFS
+    - name: Setup D drive for builds and caches
       run: |
-        $Volume = New-VHD -Path D:/mb_dev_drive.vhdx -SizeBytes 20GB |
-                  Mount-VHD -Passthru |
-                  Initialize-Disk -Passthru |
-                  New-Partition -AssignDriveLetter -UseMaximumSize |
-                  Format-Volume -FileSystem NTFS -Confirm:$false -Force
-        Write-Output $Volume
-        Write-Output "DEV_DRIVE=$($Volume.DriveLetter):" >> $env:GITHUB_ENV
-        Write-Output "CARGO_HOME=$($Volume.DriveLetter):\.cargo" >> $env:GITHUB_ENV
-        Write-Output "RUSTUP_HOME=$($Volume.DriveLetter):\.rustup" >> $env:GITHUB_ENV
-        Write-Output "SCCACHE_DIR=$($Volume.DriveLetter):\.sccache-cache" >> $env:GITHUB_ENV
+        Write-Output "DEV_DRIVE=D:" >> $env:GITHUB_ENV
+        Write-Output "CARGO_HOME=D:\.cargo" >> $env:GITHUB_ENV
+        Write-Output "RUSTUP_HOME=D:\.rustup" >> $env:GITHUB_ENV
+        Write-Output "SCCACHE_DIR=D:\.sccache-cache" >> $env:GITHUB_ENV
 
     - name: Copy Git Repo to Dev Drive
       run: |

--- a/.github/workflows/release-win-x64.yml
+++ b/.github/workflows/release-win-x64.yml
@@ -231,3 +231,10 @@ jobs:
         artifacts: "${{ env.DEV_DRIVE }}/momentobooth/build/windows/x64/runner/Release/MomentoBooth-${{ steps.extract_release_version.outputs.release_version }}-Win-x64.zip,${{ env.DEV_DRIVE }}/momentobooth/windows/installer/MomentoBooth-${{ steps.extract_release_version.outputs.release_version }}-Win-x64-Setup.exe"
         body: |
           For Windows users: MomentoBooth needs the [Visual C++ Redistributable runtime libraries](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170). The setup version will install these automatically. When using the zip, install them manually.
+
+    - name: Upload libgphoto2 package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: MSYS2 libgphoto2 package
+        path: ${{ env.DEV_DRIVE }}/MINGW-packages/mingw-w64-libgphoto2/mingw-w64-clang-x86_64-libgphoto2-*-any.pkg.tar.zst
+        compression-level: 0

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,9 +8,5 @@
     "**/.dart_tool": true,
     ".flatpak/**": true,
     "_build/**": true
-  },
-  "flutterTools.displayGetxContextMenu": false,
-  "flutterTools.displayMobxContextMenu": true,
-  "flutterTools.displayRiverpodContextMenu": false,
-  "flutterTools.displayModularContextMenu": true
+  }
 }

--- a/lib/views/settings_screen/settings_screen.dart
+++ b/lib/views/settings_screen/settings_screen.dart
@@ -6,9 +6,11 @@ import 'package:momento_booth/views/settings_screen/settings_screen_view_model.d
 
 class SettingsScreen extends ScreenBase<SettingsScreenViewModel, SettingsScreenController, SettingsScreenView> {
 
+  final SettingsPageKey initialPage;
+
   static const String defaultRoute = "/settings";
 
-  const SettingsScreen({super.key});
+  const SettingsScreen({super.key, this.initialPage = SettingsPageKey.project});
 
   @override
   SettingsScreenController createController({required SettingsScreenViewModel viewModel, required BuildContextAccessor contextAccessor}) {
@@ -17,7 +19,7 @@ class SettingsScreen extends ScreenBase<SettingsScreenViewModel, SettingsScreenC
 
   @override
   SettingsScreenView createView({required SettingsScreenController controller, required SettingsScreenViewModel viewModel, required BuildContextAccessor contextAccessor}) {
-    return SettingsScreenView(viewModel: viewModel, controller: controller, contextAccessor: contextAccessor);
+    return SettingsScreenView(viewModel: viewModel, controller: controller, contextAccessor: contextAccessor, initialPage: initialPage);
   }
 
   @override

--- a/lib/views/settings_screen/settings_screen_view.dart
+++ b/lib/views/settings_screen/settings_screen_view.dart
@@ -50,17 +50,26 @@ part 'pages/settings_screen_view.ui.dart';
 
 class SettingsScreenView extends ScreenViewBase<SettingsScreenViewModel, SettingsScreenController> {
 
-  const SettingsScreenView({
+  final GlobalKey<NavigationViewState> _navigationPaneKey = GlobalKey();
+
+  SettingsScreenView({
     required super.viewModel,
     required super.controller,
     required super.contextAccessor,
-  });
+    required SettingsPageKey initialPage,
+  }) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      NavigationPane pane = _navigationPaneKey.currentState!.widget.pane!;
+      pane.changeTo(pane.allItems.firstWhere((item) => (item.key as ValueKey?)?.value == initialPage));
+    });
+  }
 
   @override
   Widget get body {
     return Observer(
       builder: (context) {
         return NavigationView(
+          key: _navigationPaneKey,
           pane: NavigationPane(
             selected: viewModel.paneIndex,
             onChanged: controller.onNavigationPaneIndexChanged,
@@ -68,48 +77,57 @@ class SettingsScreenView extends ScreenViewBase<SettingsScreenViewModel, Setting
               PaneItemSeparator(color: Colors.transparent),
               PaneItemHeader(header: const Text('Project')),
               PaneItem(
+                key: ValueKey(SettingsPageKey.project),
                 icon: const Icon(LucideIcons.folderCog),
                 title: const Text("Project"),
                 body: Builder(builder: (_) => _getProjectSettings(viewModel, controller)),
               ),
               PaneItemHeader(header: const Text('App')),
               PaneItem(
+                key: ValueKey(SettingsPageKey.import),
                 icon: const Icon(LucideIcons.import),
                 title: const Text("Import"),
                 body: Builder(builder: (_) => _getImportSettings(viewModel, controller)),
               ),
               PaneItem(
+                key: ValueKey(SettingsPageKey.general),
                 icon: const Icon(LucideIcons.settings),
                 title: const Text("General"),
                 body: Builder(builder: (_) => _getGeneralSettings(viewModel, controller)),
               ),
               PaneItem(
+                key: ValueKey(SettingsPageKey.hardware),
                 icon: const Icon(LucideIcons.cable),
                 title: const Text("Hardware"),
                 body: Builder(builder: (_) => _getHardwareSettings(viewModel, controller)),
               ),
               PaneItem(
+                key: ValueKey(SettingsPageKey.output),
                 icon: const Icon(LucideIcons.send),
                 title: const Text("Output"),
                 body: Builder(builder: (_) => _getOutputSettings(viewModel, controller)),
               ),
               PaneItem(
+                key: ValueKey(SettingsPageKey.ui),
                 icon: const Icon(LucideIcons.appWindow),
                 title: const Text("User interface"),
                 body: Builder(builder: (_) => _getUiSettings(viewModel, controller)),
               ),
               PaneItem(
+                key: ValueKey(SettingsPageKey.templating),
                 icon: const Icon(LucideIcons.layoutTemplate),
                 title: const Text("Templating"),
                 body: Builder(builder: (_) => _getTemplatingSettings(viewModel, controller)),
               ),
               PaneItem(
+                key: ValueKey(SettingsPageKey.mqtt),
                 icon: const Icon(LucideIcons.workflow),
                 title: const Text("MQTT integration"),
                 body: Builder(builder: (_) => _getMqttIntegrationSettings(viewModel, controller)),
                 infoBadge: const MqttConnectionStateIndicator(),
               ),
               PaneItem(
+                key: ValueKey(SettingsPageKey.faceRecognition),
                 icon: const Icon(LucideIcons.scanFace),
                 title: const Text("Face recognition"),
                 body: Builder(builder: (_) => _getFaceRecognitionSettings(viewModel, controller)),
@@ -117,27 +135,32 @@ class SettingsScreenView extends ScreenViewBase<SettingsScreenViewModel, Setting
             ],
             footerItems: [
               PaneItem(
+                key: ValueKey(SettingsPageKey.subsystemStatus),
                 icon: const Icon(LucideIcons.messageSquareWarning),
                 title: const Text("Subsystem status"),
                 body: Builder(builder: (_) => _getSubsystemStatusTab(viewModel, controller)),
                 infoBadge: SubsystemStatusIcon(status: viewModel.badgeStatus),
               ),
               PaneItem(
+                key: ValueKey(SettingsPageKey.stats),
                 icon: const Icon(LucideIcons.chartLine),
                 title: const Text("Statistics"),
                 body: Builder(builder: (_) => _getStatsTab(viewModel, controller)),
               ),
               PaneItem(
+                key: ValueKey(SettingsPageKey.debug),
                 icon: const Icon(LucideIcons.bug),
                 title: const Text("Debug"),
                 body: Builder(builder: (_) => _getDebugTab(viewModel, controller)),
               ),
               PaneItem(
+                key: ValueKey(SettingsPageKey.log),
                 icon: const Icon(LucideIcons.scrollText),
                 title: const Text("Log"),
                 body: Builder(builder: (_) => _log),
               ),
               PaneItem(
+                key: ValueKey(SettingsPageKey.about),
                 icon: const Icon(LucideIcons.info),
                 title: const Text("About"),
                 body: Builder(builder: (_) => _aboutTab),
@@ -166,5 +189,25 @@ class SettingsScreenView extends ScreenViewBase<SettingsScreenViewModel, Setting
       ),
     );
   }
+
+}
+
+enum SettingsPageKey {
+
+  project,
+  import,
+  general,
+  hardware,
+  output,
+  ui,
+  templating,
+  mqtt,
+  faceRecognition,
+
+  subsystemStatus,
+  stats,
+  debug,
+  log,
+  about;
 
 }

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -69,11 +69,11 @@ set_target_properties(${BINARY_NAME}
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/intermediates_do_not_run"
 )
 
-
 # Generated plugin build rules, which manage building the plugins and adding
 # them to the application.
 include(flutter/generated_plugins.cmake)
 
+target_link_libraries(${BINARY_NAME} PRIVATE ${MIMALLOC_LIB})
 
 # === Installation ===
 # By default, "installing" just makes a relocatable bundle in the build

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -58,10 +58,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: "0c64e928dcbefddecd234205422bcfc2b5e6d31be0b86fef0d0dd48d7b4c9742"
+      sha256: "7dcbd0f87fe5f61cb28da39a1a8b70dbc106e2fe0516f7836eb7bb2948481a12"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.4"
+    version: "4.0.5"
   args:
     dependency: "direct main"
     description:
@@ -680,10 +680,10 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: "13d3349ace88f12f4a0d175eb5c12dcdd39d35c4c109a8a13dfeb6d0bd9e31c3"
+      sha256: "4e973fcf4caae1a4be2fa0a13157aa38a8f9cb049db6529aa00b4d71abc4d928"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.3"
+    version: "4.5.4"
   inspector:
     dependency: transitive
     description:
@@ -880,10 +880,10 @@ packages:
     dependency: transitive
     description:
       name: media_kit
-      sha256: "1f1deee148533d75129a6f38251ff8388e33ee05fc2d20a6a80e57d6051b7b62"
+      sha256: "48c10c3785df5d88f0eef970743f8c99b2e5da2b34b9d8f9876e598f62d9e776"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.11"
+    version: "1.2.0"
   media_kit_libs_linux:
     dependency: "direct main"
     description:
@@ -1199,10 +1199,10 @@ packages:
     dependency: transitive
     description:
       name: safe_local_storage
-      sha256: ede4eb6cb7d88a116b3d3bf1df70790b9e2038bc37cb19112e381217c74d9440
+      sha256: e9a21b6fec7a8aa62cc2585ff4c1b127df42f3185adbd2aca66b47abe2e80236
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "2.0.1"
   screen_retriever:
     dependency: transitive
     description:
@@ -1525,10 +1525,10 @@ packages:
     dependency: transitive
     description:
       name: uri_parser
-      sha256: "6543c9fd86d2862fac55d800a43e67c0dcd1a41677cb69c2f8edfe73bbcf1835"
+      sha256: ff4d2c720aca3f4f7d5445e23b11b2d15ef8af5ddce5164643f38ff962dcb270
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "3.0.0"
   url_launcher:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1120,10 +1120,10 @@ packages:
     dependency: transitive
     description:
       name: provider
-      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
+      sha256: "489024f942069c2920c844ee18bb3d467c69e48955a4f32d1677f71be103e310"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.2"
+    version: "6.1.4"
   pub_semver:
     dependency: transitive
     description:
@@ -1549,10 +1549,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: "16a513b6c12bb419304e72ea0ae2ab4fed569920d1c7cb850263fe3acc824626"
+      sha256: "7f2022359d4c099eea7df3fdf739f7d3d3b9faf3166fb1dd390775176e0b76cb"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.2"
+    version: "6.3.3"
   url_launcher_linux:
     dependency: transitive
     description:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1611,14 +1611,15 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "b2fd658b06e56721792c5df4475705b6cda790e9298d19d2f8af083457bcd127"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys 0.8.7",
  "iana-time-zone-haiku",
  "js-sys",
+ "log 0.4.27",
  "wasm-bindgen",
  "windows-core",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1020,9 +1020,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1592,9 +1592,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
 dependencies = [
  "bytes 1.10.1",
  "futures-channel",
@@ -1602,6 +1602,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
+ "libc",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1611,9 +1612,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.62"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2fd658b06e56721792c5df4475705b6cda790e9298d19d2f8af083457bcd127"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys 0.8.7",
@@ -1674,9 +1675,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
 
 [[package]]
 name = "icu_normalizer"
@@ -1698,9 +1699,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
 
 [[package]]
 name = "icu_properties"
@@ -1719,9 +1720,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
 
 [[package]]
 name = "icu_provider"
@@ -1932,10 +1933,11 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom 0.3.2",
  "libc",
 ]
 
@@ -2548,9 +2550,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.1"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "opaque-debug"
@@ -3342,9 +3344,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
@@ -3626,9 +3628,9 @@ checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -3855,7 +3857,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.3",
+ "rustix 1.0.5",
  "windows-sys 0.59.0",
 ]
 
@@ -4644,11 +4646,37 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings 0.4.0",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2 1.0.94",
+ "quote 1.0.40",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2 1.0.94",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4664,7 +4692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result",
- "windows-strings",
+ "windows-strings 0.3.1",
  "windows-targets 0.53.0",
 ]
 
@@ -4682,6 +4710,15 @@ name = "windows-strings"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
 dependencies = [
  "windows-link",
 ]


### PR DESCRIPTION
This PR:
- Updates dependencies
- Removes the creation of a custom dev drive in the Windows pipelines (as there is no actual benefit)
- Enables mimalloc for the Linux builds (as [advised](https://github.com/media-kit/media-kit?tab=readme-ov-file#utilize-mimalloc) by media-kit)
- Update Rust caching paths in the macOS pipelines to hopefully speed up builds
- Adds a (currently not yet utilized) method for opening the Settings screen on any given page
- Adds uploading of the custom libgphoto2 MSYS2 package as artifact, for verification and issue reproducibility