### PR TITLE
Deduplicate capture code

### DIFF
--- a/lib/managers/photos_manager.dart
+++ b/lib/managers/photos_manager.dart
@@ -1,14 +1,19 @@
 import 'dart:io';
-import 'dart:typed_data';
 
+import 'package:flutter/services.dart';
 import 'package:mobx/mobx.dart';
+import 'package:momento_booth/hardware_control/gphoto2_camera.dart';
+import 'package:momento_booth/hardware_control/photo_capturing/live_view_stream_snapshot_capturer.dart';
+import 'package:momento_booth/hardware_control/photo_capturing/photo_capture_method.dart';
+import 'package:momento_booth/hardware_control/photo_capturing/sony_remote_photo_capture.dart';
 import 'package:momento_booth/main.dart';
-import 'package:momento_booth/managers/project_manager.dart';
-import 'package:momento_booth/managers/settings_manager.dart';
+import 'package:momento_booth/managers/_all.dart';
+import 'package:momento_booth/models/capture_state.dart';
 import 'package:momento_booth/models/photo_capture.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/utils/file_utils.dart';
 import 'package:momento_booth/utils/hardware.dart';
+import 'package:momento_booth/utils/logger.dart';
 import 'package:path/path.dart' show basename, join; // Without show mobx complains
 import 'package:path_provider/path_provider.dart';
 
@@ -17,7 +22,7 @@ part 'photos_manager.g.dart';
 class PhotosManager = PhotosManagerBase with _$PhotosManager;
 
 /// Class containing global state for photos in the app
-abstract class PhotosManagerBase with Store {
+abstract class PhotosManagerBase with Store, Logger {
 
   @observable
   ObservableList<PhotoCapture> photos = ObservableList<PhotoCapture>();
@@ -85,6 +90,59 @@ abstract class PhotosManagerBase with Store {
   }
 
   Future<Uint8List> getOutputPDF(PrintSize printSize) => getImagePdfWithPageSize(outputImage!, printSize);
+
+  PhotoCaptureMethod get capturer => switch (getIt<SettingsManager>().settings.hardware.captureMethod) {
+    CaptureMethod.liveViewSource => LiveViewStreamSnapshotCapturer(),
+    CaptureMethod.sonyImagingEdgeDesktop => SonyRemotePhotoCapture(getIt<SettingsManager>().settings.hardware.captureLocation),
+    CaptureMethod.gPhoto2 => getIt<LiveViewManager>().gPhoto2Camera!,
+  };
+
+  Future<void> directPhotoCapture() async {
+    final capturer = this.capturer;
+    await capturer.clearPreviousEvents();
+    await captureAndGetPhoto(capturer, () => {});
+  }
+
+  void initiateDelayedPhotoCapture(VoidCallback onCaptureFinished) {
+    final capturer = this.capturer
+    ..clearPreviousEvents();
+
+    const flashStartDuration = Duration(milliseconds: 50);
+    const flashEndDuration = Duration(milliseconds: 2500);
+    const minimumContinueWait = Duration(milliseconds: 1500);
+
+    final counterStart = getIt<SettingsManager>().settings.captureDelaySeconds;
+    final autoFocusMsBeforeCapture = getIt<SettingsManager>().settings.hardware.gPhoto2AutoFocusMsBeforeCapture;
+    final photoDelay = Duration(seconds: counterStart) - capturer.captureDelay + flashStartDuration;
+    final autoFocusDelay = photoDelay - Duration(milliseconds: autoFocusMsBeforeCapture);
+
+    if (autoFocusMsBeforeCapture > 0 && autoFocusDelay > Duration.zero && capturer is GPhoto2Camera) {
+      Future.delayed(autoFocusDelay).then((_) => capturer.autoFocus());
+    }
+
+    Future.delayed(photoDelay).then((_) => captureAndGetPhoto(capturer, onCaptureFinished));
+    getIt<MqttManager>().publishCaptureState(CaptureState.countdown);
+  }
+
+  Future<void> captureAndGetPhoto(PhotoCaptureMethod capturer, VoidCallback onCaptureFinished) async {
+    getIt<MqttManager>().publishCaptureState(CaptureState.capturing);
+
+    try {
+      final image = await capturer.captureAndGetPhoto();
+      getIt<StatsManager>().addCapturedPhoto();
+      photos.add(image);
+    } catch (error) {
+      logWarning(error);
+      final ByteData data = await rootBundle.load('assets/bitmap/capture-error.png');
+      photos.add(PhotoCapture(
+        data: data.buffer.asUint8List(),
+        filename: "capture-error.png",
+      ));
+    } finally {
+      onCaptureFinished();
+      getIt<MqttManager>().publishCaptureState(CaptureState.idle);
+    }
+  }
 
 }
 

--- a/lib/models/_all.dart
+++ b/lib/models/_all.dart
@@ -1,6 +1,7 @@
 export 'app_version_info.dart';
 export 'capture_state.dart';
 export 'connection_state.dart';
+export 'constants.dart';
 export 'gallery_group.dart';
 export 'gallery_image.dart';
 export 'live_view_frame.dart';

--- a/lib/models/constants.dart
+++ b/lib/models/constants.dart
@@ -1,0 +1,3 @@
+const flashStartDuration = Duration(milliseconds: 50);
+const flashEndDuration = Duration(milliseconds: 2500);
+const minimumContinueWait = Duration(milliseconds: 1500);

--- a/lib/views/photo_booth_screen/screens/capture_screen/capture_screen_view_model.dart
+++ b/lib/views/photo_booth_screen/screens/capture_screen/capture_screen_view_model.dart
@@ -6,6 +6,7 @@ import 'package:mobx/mobx.dart';
 import 'package:momento_booth/hardware_control/photo_capturing/photo_capture_method.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
+import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
 import 'package:momento_booth/models/constants.dart';
@@ -95,7 +96,13 @@ abstract class CaptureScreenViewModelBase extends ScreenViewModelBase with Store
     navigateAfterCapture();
   }
 
-  void onCaptureFinished() {
+  Future<void> onCaptureFinished() async {
+    if (getIt<ProjectManager>().settings.singlePhotoIsCollage) {
+      await captureCollage();
+    } else {
+      getIt<PhotosManager>().outputImage = getIt<PhotosManager>().photos.last.data;
+      await getIt<PhotosManager>().writeOutput();
+    }
     captureComplete = true;
     navigateAfterCapture();
   }

--- a/lib/views/photo_booth_screen/screens/capture_screen/capture_screen_view_model.dart
+++ b/lib/views/photo_booth_screen/screens/capture_screen/capture_screen_view_model.dart
@@ -30,9 +30,6 @@ abstract class CaptureScreenViewModelBase extends ScreenViewModelBase with Store
   double get collageAspectRatio => getIt<SettingsManager>().settings.collageAspectRatio;
   double get collagePadding => getIt<SettingsManager>().settings.collagePadding;
 
-  @computed
-  Duration get photoDelay => getIt<PhotosManager>().photoDelay;
-
   @observable
   bool showCounter = true;
 

--- a/lib/views/photo_booth_screen/screens/multi_capture_screen/multi_capture_screen_view_model.dart
+++ b/lib/views/photo_booth_screen/screens/multi_capture_screen/multi_capture_screen_view_model.dart
@@ -4,6 +4,7 @@ import 'package:momento_booth/hardware_control/photo_capturing/photo_capture_met
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
+import 'package:momento_booth/models/constants.dart';
 import 'package:momento_booth/views/base/screen_view_model_base.dart';
 import 'package:momento_booth/views/photo_booth_screen/screens/collage_maker_screen/collage_maker_screen.dart';
 import 'package:momento_booth/views/photo_booth_screen/screens/multi_capture_screen/multi_capture_screen.dart';
@@ -17,19 +18,14 @@ abstract class MultiCaptureScreenViewModelBase extends ScreenViewModelBase with 
   late final PhotoCaptureMethod capturer;
   bool flashComplete = false;
   bool captureComplete = false;
-  static const flashStartDuration = Duration(milliseconds: 50);
-  static const flashEndDuration = Duration(milliseconds: 2500);
-  static const minimumContinueWait = Duration(milliseconds: 1500);
 
   int get counterStart => getIt<SettingsManager>().settings.captureDelaySeconds;
-  int get autoFocusMsBeforeCapture => getIt<SettingsManager>().settings.hardware.gPhoto2AutoFocusMsBeforeCapture;
   double get aspectRatio => getIt<SettingsManager>().settings.hardware.liveViewAndCaptureAspectRatio;
 
-  @computed
-  Duration get photoDelay => Duration(seconds: counterStart) - capturer.captureDelay + flashStartDuration;
+  PhotosManager get photosManager => getIt<PhotosManager>();
 
   @computed
-  Duration get autoFocusDelay => photoDelay - Duration(milliseconds: autoFocusMsBeforeCapture);
+  Duration get photoDelay => getIt<PhotosManager>().photoDelay;
 
   @observable
   bool showCounter = true;

--- a/lib/views/photo_booth_screen/screens/multi_capture_screen/multi_capture_screen_view_model.dart
+++ b/lib/views/photo_booth_screen/screens/multi_capture_screen/multi_capture_screen_view_model.dart
@@ -24,9 +24,6 @@ abstract class MultiCaptureScreenViewModelBase extends ScreenViewModelBase with 
 
   PhotosManager get photosManager => getIt<PhotosManager>();
 
-  @computed
-  Duration get photoDelay => getIt<PhotosManager>().photoDelay;
-
   @observable
   bool showCounter = true;
 


### PR DESCRIPTION
The code to initiate a delayed capture was duplicated in both the single- and multi-capture screens.
This PR solves that by moving the capture logic (including time calculation) to the `PhotosManager`. The `FindFaceDialog`'s code has also been simplified with this change. A custom countdown delay was used there before, so the option for this is also implemented in the new method.

The timing division is now as follows:
The flash in the _capture screens_ is activated after the counter ends (# of seconds set in settings).
The actual capture delay is now calculated in the `PhotosManager`. As before, it takes the countdown length, flash, and capture delay time (caused by e.g. focussing) into account.