### PR TITLE
Fix gallery empty screen when PNGs are present in output folder

### DIFF
--- a/lib/models/gallery_image.dart
+++ b/lib/models/gallery_image.dart
@@ -17,9 +17,10 @@ abstract class GalleryImage with _$GalleryImage {
     required List<MomentoBoothExifTag> exifTags,
   }) = _GalleryImage;
 
-  DateTime? get createdDate => exifTags
+  /// Returns the created date of the image, based on the EXIF data, or file last modified timestamp.
+  DateTime get createdDate => exifTags
     .whereType<MomentoBoothExifTag_CreateDate>()
-    .firstOrNull?.field0;
+    .firstOrNull?.field0 ?? file.lastModifiedSync();
 
   MakerNoteData? get makerNoteData {
     String? json = exifTags

--- a/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_view_model.dart
+++ b/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_view_model.dart
@@ -104,7 +104,7 @@ abstract class GalleryScreenViewModelBase extends ScreenViewModelBase with Store
               images: entry.value
                 ..sort((a, b) => b.createdDate.compareTo(a.createdDate))))
           .toList()
-        ..sort((a, b) => (b.createdDayAndHour ?? DateTime(1970)).compareTo(a.createdDayAndHour ?? DateTime(1970)));
+        ..sort((a, b) => (b.createdDayAndHour!).compareTo(a.createdDayAndHour!));
 
       _imageGroups = imageGroups;
     } else {

--- a/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_view_model.dart
+++ b/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_view_model.dart
@@ -89,7 +89,7 @@ abstract class GalleryScreenViewModelBase extends ScreenViewModelBase with Store
       // Group images and sort within groups
       List<GalleryGroup> imageGroups = imagesWithExif
           .groupListsBy((image) {
-              var date = image.createdDate ?? image.file.lastModifiedSync();
+              var date = image.createdDate;
               return DateTime(
                 date.year,
                 date.month,
@@ -102,7 +102,7 @@ abstract class GalleryScreenViewModelBase extends ScreenViewModelBase with Store
               title: formatter.format(entry.key),
               createdDayAndHour: entry.key,
               images: entry.value
-                ..sort((a, b) => (b.createdDate ?? DateTime(1970)).compareTo(a.createdDate ?? DateTime(1970)))))
+                ..sort((a, b) => b.createdDate.compareTo(a.createdDate))))
           .toList()
         ..sort((a, b) => (b.createdDayAndHour ?? DateTime(1970)).compareTo(a.createdDayAndHour ?? DateTime(1970)));
 

--- a/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_view_model.dart
+++ b/lib/views/photo_booth_screen/screens/gallery_screen/gallery_screen_view_model.dart
@@ -88,17 +88,18 @@ abstract class GalleryScreenViewModelBase extends ScreenViewModelBase with Store
     if (sortBy == SortBy.time) {
       // Group images and sort within groups
       List<GalleryGroup> imageGroups = imagesWithExif
-          .groupListsBy((image) => image.createdDate != null
-              ? DateTime(
-                  image.createdDate!.year,
-                  image.createdDate!.month,
-                  image.createdDate!.day,
-                  image.createdDate!.hour,
-                )
-              : null)
+          .groupListsBy((image) {
+              var date = image.createdDate ?? image.file.lastModifiedSync();
+              return DateTime(
+                date.year,
+                date.month,
+                date.day,
+                date.hour,
+              );
+          })
           .entries
           .map((entry) => GalleryGroup(
-              title: formatter.format(entry.key!),
+              title: formatter.format(entry.key),
               createdDayAndHour: entry.key,
               images: entry.value
                 ..sort((a, b) => (b.createdDate ?? DateTime(1970)).compareTo(a.createdDate ?? DateTime(1970)))))


### PR DESCRIPTION
Because of the changes introduced in #389 to improve upon #365, a null check operator could be used on a null value in the generation of the title for the `GalleryGroup`s.
Since the for the `creationDate` is sourced from the EXIF data, and PNG images do not have EXIF data, this failed and the title of the group could not be constructed.

This PR solves this by using the **file**'s modified date as a fallback for when no EXIF data is present.