### PR TITLE
Fix the Windows pipeline bundling script not crashing on missing DLL's

### DIFF
--- a/.github/workflows/pr-ci-app-win-x64.yml
+++ b/.github/workflows/pr-ci-app-win-x64.yml
@@ -160,36 +160,7 @@ jobs:
     - name: Bundle dependencies
       working-directory: ${{ env.DEV_DRIVE }}/momentobooth
       shell: pwsh
-      run: |
-        $bundle_script = curl https://raw.githubusercontent.com/momentobooth/mingw-bundledlls/master/mingw-bundledlls
-        echo $bundle_script | python - --copy build\windows\x64\runner\Release\rust_lib_momento_booth.dll
-
-        # Bundle iolibs and camlibs
-        mkdir build\windows\x64\runner\Release\libgphoto2_iolibs
-        cp $Env:CLANG64_LIB_PATH\libgphoto2_port\*\*.dll build\windows\x64\runner\Release\libgphoto2_iolibs
-        mkdir build\windows\x64\runner\Release\libgphoto2_camlibs
-        cp $Env:CLANG64_LIB_PATH\libgphoto2\*\*.dll build\windows\x64\runner\Release\libgphoto2_camlibs
-
-        # Bundle dependency libs
-        cd build\windows\x64\runner\Release\
-        $lib_folders = @('libgphoto2_iolibs', 'libgphoto2_camlibs')
-        foreach ( $folder in $lib_folders )
-        {
-          $libs = ls $folder
-          foreach ( $lib in $libs )
-          {
-            echo $bundle_script | python - --copy $lib.fullName
-          }
-
-          # Now move all libraries to the same folder as the executable (except iolibs and camlibs themselves)
-          $files = ls $folder
-          foreach ( $file in $files )
-          {
-            if ($libs.Name -notcontains $file.Name) {
-              Move-Item -Path $file -Destination $file.Directory.Parent.FullName -force
-            }
-          }
-        }
+      run: .\windows\bundle_libs.ps1
 
     - name: Compile Inno Setup installer
       shell: pwsh

--- a/.github/workflows/release-win-x64.yml
+++ b/.github/workflows/release-win-x64.yml
@@ -167,36 +167,7 @@ jobs:
     - name: Bundle dependencies
       working-directory: ${{ env.DEV_DRIVE }}/momentobooth
       shell: pwsh
-      run: |
-        $bundle_script = curl https://raw.githubusercontent.com/momentobooth/mingw-bundledlls/master/mingw-bundledlls
-        echo $bundle_script | python - --copy build\windows\x64\runner\Release\rust_lib_momento_booth.dll
-
-        # Bundle iolibs and camlibs
-        mkdir build\windows\x64\runner\Release\libgphoto2_iolibs
-        cp $Env:CLANG64_LIB_PATH\libgphoto2_port\*\*.dll build\windows\x64\runner\Release\libgphoto2_iolibs
-        mkdir build\windows\x64\runner\Release\libgphoto2_camlibs
-        cp $Env:CLANG64_LIB_PATH\libgphoto2\*\*.dll build\windows\x64\runner\Release\libgphoto2_camlibs
-
-        # Bundle dependency libs
-        cd build\windows\x64\runner\Release\
-        $lib_folders = @('libgphoto2_iolibs', 'libgphoto2_camlibs')
-        foreach ( $folder in $lib_folders )
-        {
-          $libs = ls $folder
-          foreach ( $lib in $libs )
-          {
-            echo $bundle_script | python - --copy $lib.fullName
-          }
-
-          # Now move all libraries to the same folder as the executable (except iolibs and camlibs themselves)
-          $files = ls $folder
-          foreach ( $file in $files )
-          {
-            if ($libs.Name -notcontains $file.Name) {
-              Move-Item -Path $file -Destination $file.Directory.Parent.FullName -force
-            }
-          }
-        }
+      run: .\windows\bundle_libs.ps1
 
     - name: Compile Inno Setup installer
       shell: pwsh

--- a/windows/bundle_libs.ps1
+++ b/windows/bundle_libs.ps1
@@ -1,0 +1,33 @@
+$bundle_script = curl https://raw.githubusercontent.com/momentobooth/mingw-bundledlls/master/mingw-bundledlls
+Write-Output "Running bundling for rust_lib_momento_booth.dll"
+Write-Output $bundle_script | python - --copy build\windows\x64\runner\Release\rust_lib_momento_booth.dll
+if ($LastExitCode -ne 0) { throw "mingw-bundledlls failed with exit code $LastExitCode" }
+
+# Bundle iolibs and camlibs themselves.
+mkdir build\windows\x64\runner\Release\libgphoto2_iolibs
+Copy-Item $Env:CLANG64_LIB_PATH\libgphoto2_port\*\*.dll build\windows\x64\runner\Release\libgphoto2_iolibs
+mkdir build\windows\x64\runner\Release\libgphoto2_camlibs
+Copy-Item $Env:CLANG64_LIB_PATH\libgphoto2\*\*.dll build\windows\x64\runner\Release\libgphoto2_camlibs
+
+# Bundle dependency libs.
+Set-Location build\windows\x64\runner\Release\
+$lib_folders = @('libgphoto2_iolibs', 'libgphoto2_camlibs')
+foreach ( $folder in $lib_folders )
+{
+  $libs = Get-ChildItem $folder
+  foreach ( $lib in $libs )
+  {
+    Write-Output "Running bundling for $lib"
+    Write-Output $bundle_script | python - --copy $lib.fullName
+    if ($LastExitCode -ne 0) { throw "mingw-bundledlls failed with exit code $LastExitCode" }
+  }
+
+  # Now move all libraries to the same folder as the executable (except iolibs and camlibs themselves).
+  $files = Get-ChildItem $folder
+  foreach ( $file in $files )
+  {
+    if ($libs.Name -notcontains $file.Name) {
+      Move-Item -Path $file -Destination $file.Directory.Parent.FullName -force
+    }
+  }
+}


### PR DESCRIPTION
Additionally move the script to a separate file