### PR TITLE
Systems health check

### DIFF
--- a/.github/workflows/pr-ci-app-linux-appimage-x64.yml
+++ b/.github/workflows/pr-ci-app-linux-appimage-x64.yml
@@ -63,7 +63,7 @@ jobs:
       uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Install cargo-binstall
-      uses: cargo-bins/cargo-binstall@v1.14.4
+      uses: cargo-bins/cargo-binstall@main
 
     - name: Install cargo-expand
       run: cargo binstall cargo-expand --force

--- a/.github/workflows/pr-ci-app-macos-arm64.yml
+++ b/.github/workflows/pr-ci-app-macos-arm64.yml
@@ -87,7 +87,7 @@ jobs:
       uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Install cargo-binstall
-      uses: cargo-bins/cargo-binstall@v1.14.4
+      uses: cargo-bins/cargo-binstall@main
 
     - name: Install cargo-expand
       run: cargo binstall cargo-expand --force

--- a/.github/workflows/pr-ci-app-win-x64.yml
+++ b/.github/workflows/pr-ci-app-win-x64.yml
@@ -87,7 +87,7 @@ jobs:
       uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Install cargo-binstall
-      uses: cargo-bins/cargo-binstall@v1.14.4
+      uses: cargo-bins/cargo-binstall@main
 
     - name: Install cargo-expand
       run: cargo binstall cargo-expand --force

--- a/.github/workflows/release-linux-appimage-x64.yml
+++ b/.github/workflows/release-linux-appimage-x64.yml
@@ -62,7 +62,7 @@ jobs:
       uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Install cargo-binstall
-      uses: cargo-bins/cargo-binstall@v1.14.4
+      uses: cargo-bins/cargo-binstall@main
 
     - name: Install cargo-expand
       run: cargo binstall cargo-expand --force

--- a/.github/workflows/release-macos-arm64.yml
+++ b/.github/workflows/release-macos-arm64.yml
@@ -81,7 +81,7 @@ jobs:
       uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Install cargo-binstall
-      uses: cargo-bins/cargo-binstall@v1.14.4
+      uses: cargo-bins/cargo-binstall@main
 
     - name: Install cargo-expand
       run: cargo binstall cargo-expand --force

--- a/.github/workflows/release-win-x64.yml
+++ b/.github/workflows/release-win-x64.yml
@@ -86,7 +86,7 @@ jobs:
       uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Install cargo-binstall
-      uses: cargo-bins/cargo-binstall@v1.14.4
+      uses: cargo-bins/cargo-binstall@main
 
     - name: Install cargo-expand
       run: cargo binstall cargo-expand --force

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:mobx/mobx.dart';
 import 'package:momento_booth/app.dart';
 import 'package:momento_booth/extensions/get_it_extension.dart';
 import 'package:momento_booth/managers/_all.dart';
+import 'package:momento_booth/managers/external_system_status_manager.dart';
 import 'package:momento_booth/models/_all.dart';
 import 'package:momento_booth/models/project_data.dart';
 import 'package:momento_booth/models/subsystem.dart';
@@ -77,7 +78,8 @@ Future<void> _initializeApp(ArgResults args) async {
     ..registerManager(MqttManager())
     ..registerManager(NotificationsManager())
     ..registerManager(PrintingManager())
-    ..registerManager(PhotosManager());
+    ..registerManager(PhotosManager())
+    ..registerManager(ExternalSystemStatusManager());
 
   await RustLib.init();
   _initializeLog();
@@ -115,6 +117,7 @@ Future<void> _initializeApp(ArgResults args) async {
   await getIt<SfxManager>().initializeSafe();
   await getIt<PrintingManager>().initializeSafe();
   getIt<NotificationsManager>().initialize();
+  getIt<ExternalSystemStatusManager>().initialize();
 }
 
 void _initializeLog() {

--- a/lib/managers/external_system_status_manager.dart
+++ b/lib/managers/external_system_status_manager.dart
@@ -1,50 +1,51 @@
 import 'dart:async';
 import 'dart:io';
 import 'package:http/http.dart' as http;
+import 'package:mobx/mobx.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/models/settings.dart';
+import 'package:momento_booth/models/subsystem_status.dart';
 
 class ExternalSystemStatus {
   final ExternalSystemCheckSetting check;
-  final bool isHealthy;
-  final String? error;
+  final SubsystemStatus isHealthy;
 
   ExternalSystemStatus({
     required this.check,
     required this.isHealthy,
-    this.error,
   });
 }
 
 class ExternalSystemStatusManager {
-  late final List<ExternalSystemCheckSetting> checks;
+  @observable
+  List<ExternalSystemStatus> _statuses = [];
   Timer? _checkTimer;
 
-  ExternalSystemStatusManager({List<ExternalSystemCheckSetting>? checks}) {
-    if (checks != null) {
-      this.checks = checks;
-      return;
-    }
-    this.checks = getIt<SettingsManager>().settings.externalSystemChecks;
-  }
+  ExternalSystemStatusManager();
 
   /// Initializes the manager, setting up the timer for periodic checks.
   void initialize() {
     if (_checkTimer != null && _checkTimer!.isActive) {
       _checkTimer!.cancel();
     }
+    loadStatuses();
     _checkTimer = Timer.periodic(Duration(seconds: getIt<SettingsManager>().settings.externalSystemCheckIntervalSeconds), (timer) {
       runAllChecks();
     });
   }
 
-  /// Runs all health checks and returns their statuses
-  Future<List<ExternalSystemStatus>> runAllChecks() async {
-    return Future.wait(checks.map(_runCheck));
+  void loadStatuses() {
+    _statuses = getIt<SettingsManager>().settings.externalSystemChecks.map((el) => ExternalSystemStatus(check: el, isHealthy: SubsystemStatus.initial())).toList();
   }
 
-  Future<ExternalSystemStatus> _runCheck(ExternalSystemCheckSetting check) async {
+  /// Runs all health checks and returns their statuses
+  Future<List<ExternalSystemStatus>> runAllChecks() async {
+    loadStatuses();  // Fixme: we reset the isHealthy state here, which might not be ideal.
+    return Future.wait(_statuses.map((status) => runCheck(status.check)));
+  }
+
+  static Future<ExternalSystemStatus> runCheck(ExternalSystemCheckSetting check) async {
     switch (check.type) {
       case ExternalSystemCheckType.ping:
         return await _pingCheck(check);
@@ -53,7 +54,7 @@ class ExternalSystemStatusManager {
     }
   }
 
-  Future<ExternalSystemStatus> _pingCheck(ExternalSystemCheckSetting check) async {
+  static Future<ExternalSystemStatus> _pingCheck(ExternalSystemCheckSetting check) async {
     try {
       final result = await Process.run(
         Platform.isWindows ? 'ping' : 'ping',
@@ -62,32 +63,28 @@ class ExternalSystemStatusManager {
       final success = result.exitCode == 0;
       return ExternalSystemStatus(
         check: check,
-        isHealthy: success,
-        error: success ? null : result.stderr.toString(),
+        isHealthy: success ? const SubsystemStatus.ok() : SubsystemStatus.error(message: "ping unsuccessful", exception: result.stdout.toString()),
       );
     } catch (e) {
       return ExternalSystemStatus(
         check: check,
-        isHealthy: false,
-        error: e.toString(),
+        isHealthy: SubsystemStatus.error(message: "ping unsuccessful", exception: e.toString()),
       );
     }
   }
 
-  Future<ExternalSystemStatus> _httpCheck(ExternalSystemCheckSetting check) async {
+  static Future<ExternalSystemStatus> _httpCheck(ExternalSystemCheckSetting check) async {
     try {
       final response = await http.get(Uri.parse(check.address)).timeout(Duration(seconds: 5));
       final success = response.statusCode >= 200 && response.statusCode < 400;
       return ExternalSystemStatus(
         check: check,
-        isHealthy: success,
-        error: success ? null : 'HTTP ${response.statusCode}',
+        isHealthy: success ? const SubsystemStatus.ok() : SubsystemStatus.error(message: "http request unsuccessful", exception: 'HTTP ${response.statusCode}'),
       );
     } catch (e) {
       return ExternalSystemStatus(
         check: check,
-        isHealthy: false,
-        error: e.toString(),
+        isHealthy: SubsystemStatus.error(message:  "http request unsuccessful", exception: e.toString()),
       );
     }
   }

--- a/lib/managers/external_system_status_manager.dart
+++ b/lib/managers/external_system_status_manager.dart
@@ -1,23 +1,12 @@
 import 'dart:async';
 import 'dart:io';
 import 'package:http/http.dart' as http;
+import 'package:momento_booth/main.dart';
+import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/models/settings.dart';
 
-/// Represents a single external system check (ping or HTTP)
-class ExternalSystemCheck {
-  final String name;
-  final String address; // IP/hostname or URL
-  final ExternalSystemCheckType type;
-
-  ExternalSystemCheck({
-    required this.name,
-    required this.address,
-    required this.type,
-  });
-}
-
 class ExternalSystemStatus {
-  final ExternalSystemCheck check;
+  final ExternalSystemCheckSetting check;
   final bool isHealthy;
   final String? error;
 
@@ -29,16 +18,33 @@ class ExternalSystemStatus {
 }
 
 class ExternalSystemStatusManager {
-  final List<ExternalSystemCheck> checks;
+  late final List<ExternalSystemCheckSetting> checks;
+  Timer? _checkTimer;
 
-  ExternalSystemStatusManager(this.checks);
+  ExternalSystemStatusManager({List<ExternalSystemCheckSetting>? checks}) {
+    if (checks != null) {
+      this.checks = checks;
+      return;
+    }
+    this.checks = getIt<SettingsManager>().settings.externalSystemChecks;
+  }
+
+  /// Initializes the manager, setting up the timer for periodic checks.
+  void initialize() {
+    if (_checkTimer != null && _checkTimer!.isActive) {
+      _checkTimer!.cancel();
+    }
+    _checkTimer = Timer.periodic(Duration(seconds: getIt<SettingsManager>().settings.externalSystemCheckIntervalSeconds), (timer) {
+      runAllChecks();
+    });
+  }
 
   /// Runs all health checks and returns their statuses
   Future<List<ExternalSystemStatus>> runAllChecks() async {
     return Future.wait(checks.map(_runCheck));
   }
 
-  Future<ExternalSystemStatus> _runCheck(ExternalSystemCheck check) async {
+  Future<ExternalSystemStatus> _runCheck(ExternalSystemCheckSetting check) async {
     switch (check.type) {
       case ExternalSystemCheckType.ping:
         return await _pingCheck(check);
@@ -47,7 +53,7 @@ class ExternalSystemStatusManager {
     }
   }
 
-  Future<ExternalSystemStatus> _pingCheck(ExternalSystemCheck check) async {
+  Future<ExternalSystemStatus> _pingCheck(ExternalSystemCheckSetting check) async {
     try {
       final result = await Process.run(
         Platform.isWindows ? 'ping' : 'ping',
@@ -68,7 +74,7 @@ class ExternalSystemStatusManager {
     }
   }
 
-  Future<ExternalSystemStatus> _httpCheck(ExternalSystemCheck check) async {
+  Future<ExternalSystemStatus> _httpCheck(ExternalSystemCheckSetting check) async {
     try {
       final response = await http.get(Uri.parse(check.address)).timeout(Duration(seconds: 5));
       final success = response.statusCode >= 200 && response.statusCode < 400;

--- a/lib/managers/external_system_status_manager.dart
+++ b/lib/managers/external_system_status_manager.dart
@@ -1,0 +1,88 @@
+import 'dart:async';
+import 'dart:io';
+import 'package:http/http.dart' as http;
+import 'package:momento_booth/models/settings.dart';
+
+/// Represents a single external system check (ping or HTTP)
+class ExternalSystemCheck {
+  final String name;
+  final String address; // IP/hostname or URL
+  final ExternalSystemCheckType type;
+
+  ExternalSystemCheck({
+    required this.name,
+    required this.address,
+    required this.type,
+  });
+}
+
+class ExternalSystemStatus {
+  final ExternalSystemCheck check;
+  final bool isHealthy;
+  final String? error;
+
+  ExternalSystemStatus({
+    required this.check,
+    required this.isHealthy,
+    this.error,
+  });
+}
+
+class ExternalSystemStatusManager {
+  final List<ExternalSystemCheck> checks;
+
+  ExternalSystemStatusManager(this.checks);
+
+  /// Runs all health checks and returns their statuses
+  Future<List<ExternalSystemStatus>> runAllChecks() async {
+    return Future.wait(checks.map(_runCheck));
+  }
+
+  Future<ExternalSystemStatus> _runCheck(ExternalSystemCheck check) async {
+    switch (check.type) {
+      case ExternalSystemCheckType.ping:
+        return await _pingCheck(check);
+      case ExternalSystemCheckType.http:
+        return await _httpCheck(check);
+    }
+  }
+
+  Future<ExternalSystemStatus> _pingCheck(ExternalSystemCheck check) async {
+    try {
+      final result = await Process.run(
+        Platform.isWindows ? 'ping' : 'ping',
+        Platform.isWindows ? ['-n', '1', check.address] : ['-c', '1', check.address],
+      );
+      final success = result.exitCode == 0;
+      return ExternalSystemStatus(
+        check: check,
+        isHealthy: success,
+        error: success ? null : result.stderr.toString(),
+      );
+    } catch (e) {
+      return ExternalSystemStatus(
+        check: check,
+        isHealthy: false,
+        error: e.toString(),
+      );
+    }
+  }
+
+  Future<ExternalSystemStatus> _httpCheck(ExternalSystemCheck check) async {
+    try {
+      final response = await http.get(Uri.parse(check.address)).timeout(Duration(seconds: 5));
+      final success = response.statusCode >= 200 && response.statusCode < 400;
+      return ExternalSystemStatus(
+        check: check,
+        isHealthy: success,
+        error: success ? null : 'HTTP ${response.statusCode}',
+      );
+    } catch (e) {
+      return ExternalSystemStatus(
+        check: check,
+        isHealthy: false,
+        error: e.toString(),
+      );
+    }
+  }
+}

--- a/lib/managers/external_system_status_manager.dart
+++ b/lib/managers/external_system_status_manager.dart
@@ -57,8 +57,7 @@ abstract class ExternalSystemStatusManagerBase with Store, Logger {
   Future<ExternalSystemStatus> runCheck(ExternalSystemCheckSetting check) async {
     final index = systems.indexWhere((el) => el.check == check);
     if (index != -1) {
-      // Changinkg the status to busy while the check is running is fun, but it would intermittently seem that there is no issue, even if it was not resolved.
-      // systems[index] = systems[index].copyWith(inProgress: true, isHealthy: SubsystemStatus.busy(message: "Running check..."));
+      // Changing the status to busy while the check is running is fun, but it would intermittently seem that there is no issue, even if it was not resolved.
       systems[index] = systems[index].copyWith(inProgress: true);
     }
     final result = await switch (check.type) {
@@ -83,8 +82,7 @@ abstract class ExternalSystemStatusManagerBase with Store, Logger {
   static Future<ExternalSystemStatus> _pingCheck(ExternalSystemCheckSetting check) async {
     const eMessage = "ping unsuccessful";
     try {
-      final result = await Process.run(
-        Platform.isWindows ? 'ping' : 'ping',
+      final result = await Process.run('ping',
         Platform.isWindows ? ['-n', '1', check.address] : ['-c', '1', check.address],
       );
       final success = result.exitCode == 0;

--- a/lib/managers/live_view_manager.dart
+++ b/lib/managers/live_view_manager.dart
@@ -25,6 +25,9 @@ class LiveViewManager = LiveViewManagerBase with _$LiveViewManager;
 /// Class containing global state for photos in the app
 abstract class LiveViewManagerBase extends Subsystem with Store, Logger {
 
+  @override
+  String subsystemName = "Live View Manager";
+
   @readonly
   bool _lastFrameWasInvalid = false;
 

--- a/lib/managers/mqtt_manager.dart
+++ b/lib/managers/mqtt_manager.dart
@@ -29,6 +29,9 @@ class MqttManager = MqttManagerBase with _$MqttManager;
 /// Class containing global state for photos in the app
 abstract class MqttManagerBase extends Subsystem with Store, Logger {
 
+  @override
+  String subsystemName = "MQTT Manager";
+
   final Lock _updateMqttClientInstanceLock = Lock();
 
   MqttIntegrationSettings? _currentSettings;

--- a/lib/managers/notifications_manager.dart
+++ b/lib/managers/notifications_manager.dart
@@ -28,36 +28,57 @@ abstract class NotificationsManagerBase with Store {
   }
 
   Future<void> _statusCheck() async {
+    // The printer status check must be done before clearing as it is async and we don't want the notifications to blink.
+    final printerNotifications = await _printerStatusCheck();
+    notifications
+      ..clear()
+      ..addAll(printerNotifications)
+      ..addAll(_subSystemStatusCheck())
+      ..addAll(_externalSystemsStatusCheck())
+      // Sort notifications by severity, so that errors are shown first, then warnings, then info.
+      ..sort((a, b) {
+        if (a.severity == b.severity) {
+          return 0;
+        }
+        return a.severity.index > b.severity.index ? -1 : 1;
+      });
+  }
+
+  Future<List<InfoBar>> _printerStatusCheck() async {
+    final printerNotifications = List<InfoBar>.empty(growable: true);
     final printerNames = getIt<SettingsManager>().settings.hardware.flutterPrintingPrinterNames;
     final printersStatus = await compute(checkPrintersStatus, printerNames);
-    notifications.clear();
     printersStatus.forEachIndexed((index, element) {
       final hasErrorNotification = InfoBar(title: const Text("Printer error"), content: Text("Printer ${index+1} has an error."), severity: InfoBarSeverity.warning);
       final paperOutNotification = InfoBar(title: const Text("Printer out of paper"), content: Text("Printer ${index+1} is out of paper."), severity: InfoBarSeverity.warning);
       final longQueueNotification = InfoBar(title: const Text("Long printing queue"), content: Text("Printer ${index+1} has a long queue (${element.jobs} jobs). It might take a while for your print to appear."), severity: InfoBarSeverity.info);
       if (element.jobs >= getIt<SettingsManager>().settings.hardware.printerQueueWarningThreshold) {
-        notifications.add(longQueueNotification);
+        printerNotifications.add(longQueueNotification);
       }
       if (element.hasError) {
-        notifications.add(hasErrorNotification);
+        printerNotifications.add(hasErrorNotification);
       }
       if (element.paperOut) {
-        notifications.add(paperOutNotification);
+        printerNotifications.add(paperOutNotification);
       }
     });
-    
+    return printerNotifications;
+  }
+
+  List<InfoBar> _subSystemStatusCheck() {
+    final systemNotifications = List<InfoBar>.empty(growable: true);
     for (var element in getIt<ObservableList<Subsystem>>()) {
       final status = element.subsystemStatus;
       final name = element.subsystemName;
       switch (status) {
         case SubsystemStatusError():
-          notifications.add(InfoBar(
+          systemNotifications.add(InfoBar(
             title: Text("$name error"),
             content: Text("Subsystem $name has an error: ${status.message}"),
             severity: InfoBarSeverity.error,
           ));
         case SubsystemStatusWarning():
-          notifications.add(InfoBar(
+          systemNotifications.add(InfoBar(
             title: Text("$name warning"),
             content: Text("Subsystem $name has a warning: ${status.message}"),
             severity: InfoBarSeverity.warning,
@@ -66,14 +87,18 @@ abstract class NotificationsManagerBase with Store {
           break;
       }
     }
+    return systemNotifications;
+  }
 
+  List<InfoBar> _externalSystemsStatusCheck() {
+    final systemNotifications = List<InfoBar>.empty(growable: true);
     for (var element in getIt<ExternalSystemStatusManager>().systems) {
       final status = element.isHealthy;
       final severity = element.check.severity;
       final name = element.check.name;
       switch (status) {
         case SubsystemStatusError():
-          notifications.add(InfoBar(
+          systemNotifications.add(InfoBar(
             title: Text("$name unavailable"),
             content: Text("External service \"$name\" is unavailable: ${status.message}"),
             severity: InfoBarSeverity.error,
@@ -81,7 +106,7 @@ abstract class NotificationsManagerBase with Store {
         case SubsystemStatusWarning():
         // We don't show info severity notifications.
           if (severity == ExternalSystemCheckSeverity.warning) {
-            notifications.add(InfoBar(
+            systemNotifications.add(InfoBar(
               title: Text("$name unavailable"),
               content: Text("External service \"$name\" is unavailable: ${status.message}"),
               severity: InfoBarSeverity.warning,
@@ -91,14 +116,7 @@ abstract class NotificationsManagerBase with Store {
           break;
       }
     }
-
-    // Sort notifications by severity, so that errors are shown first, then warnings, then info.
-    notifications.sort((a, b) {
-      if (a.severity == b.severity) {
-        return 0;
-      }
-      return a.severity.index > b.severity.index ? -1 : 1;
-    });
+    return systemNotifications;
   }
 
 }

--- a/lib/managers/printing_manager.dart
+++ b/lib/managers/printing_manager.dart
@@ -17,6 +17,9 @@ class PrintingManager = PrintingManagerBase with _$PrintingManager;
 
 abstract class PrintingManagerBase extends Subsystem with Store, Logger {
 
+  @override
+  String subsystemName = "Printing Manager";
+
   // ////////////// //
   // Initialization //
   // ////////////// //

--- a/lib/managers/project_manager.dart
+++ b/lib/managers/project_manager.dart
@@ -21,6 +21,9 @@ class ProjectManager = ProjectManagerBase with _$ProjectManager;
 
 abstract class ProjectManagerBase extends Subsystem with Store, Logger {
 
+  @override
+  String subsystemName = "Project Manager";
+
   @readonly
   bool _isOpen = false;
   @readonly

--- a/lib/managers/settings_manager.dart
+++ b/lib/managers/settings_manager.dart
@@ -13,6 +13,9 @@ class SettingsManager = SettingsManagerBase with _$SettingsManager;
 
 abstract class SettingsManagerBase extends Subsystem with Store, Logger {
 
+  @override
+  String subsystemName = "Settings Manager";
+
   // Loading the settings with default values to prevent errors from use before initialization.
   // This is fine as the initialize method overwrites the value anyway.
   @readonly

--- a/lib/managers/sfx_manager.dart
+++ b/lib/managers/sfx_manager.dart
@@ -16,6 +16,9 @@ class SfxManager = SfxManagerBase with _$SfxManager;
 
 abstract class SfxManagerBase extends Subsystem with Store, Logger {
 
+  @override
+  String subsystemName = "SFX Manager";
+
   final Lock _updateMqttClientInstanceLock = Lock();
   static const int _testSoundId = 0, _clickSoundId = 1, _shareScreenSoundId = 2;
 

--- a/lib/managers/stats_manager.dart
+++ b/lib/managers/stats_manager.dart
@@ -14,6 +14,9 @@ class StatsManager = StatsManagerBase with _$StatsManager;
 
 abstract class StatsManagerBase extends Subsystem with Store, Logger {
 
+  @override
+  String subsystemName = "Stats Manager";
+
   @readonly
   late Stats _stats;
 

--- a/lib/managers/window_manager.dart
+++ b/lib/managers/window_manager.dart
@@ -11,6 +11,9 @@ class WindowManager = WindowManagerBase with _$WindowManager;
 
 abstract class WindowManagerBase extends Subsystem with Store, Logger {
 
+  @override
+  String subsystemName = "Window Manager";
+
   @readonly
   bool _isFullScreen = false;
 

--- a/lib/models/_all.dart
+++ b/lib/models/_all.dart
@@ -2,6 +2,7 @@ export 'app_version_info.dart';
 export 'capture_state.dart';
 export 'connection_state.dart';
 export 'constants.dart';
+export 'external_system_status.dart';
 export 'gallery_group.dart';
 export 'gallery_image.dart';
 export 'live_view_frame.dart';

--- a/lib/models/external_system_status.dart
+++ b/lib/models/external_system_status.dart
@@ -1,0 +1,23 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:momento_booth/models/settings.dart';
+import 'package:momento_booth/models/subsystem_status.dart';
+
+part 'external_system_status.freezed.dart';
+
+@freezed
+class ExternalSystemStatus with _$ExternalSystemStatus {
+  @override
+  final ExternalSystemCheckSetting check;
+  @override
+  final SubsystemStatus isHealthy;
+  @override
+  final DateTime timestamp;
+  @override
+  final bool inProgress;
+
+  ExternalSystemStatus({
+    required this.check,
+    required this.isHealthy,
+    this.inProgress = false,
+  }): timestamp = DateTime.now();
+}

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -326,6 +326,7 @@ sealed class ExternalSystemCheckSetting with _$ExternalSystemCheckSetting implem
     required String name,
     required String address,
     required ExternalSystemCheckType type,
+    @Default(true) bool enabled,
   }) = _ExternalSystemCheckSetting;
 
   factory ExternalSystemCheckSetting.withDefaults() => ExternalSystemCheckSetting.fromJson({});

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -40,6 +40,7 @@ sealed class Settings with _$Settings implements TomlEncodableValue {
     @JsonKey(defaultValue: FaceRecognitionSettings.withDefaults) required FaceRecognitionSettings faceRecognition,
     @JsonKey(defaultValue: DebugSettings.withDefaults) required DebugSettings debug,
     @Default([]) List<ExternalSystemCheckSetting> externalSystemChecks,
+    @Default(60) int externalSystemCheckIntervalSeconds,
   }) = _Settings;
 
   factory Settings.withDefaults() => Settings.fromJson({});

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -39,6 +39,7 @@ sealed class Settings with _$Settings implements TomlEncodableValue {
     @JsonKey(defaultValue: MqttIntegrationSettings.withDefaults) required MqttIntegrationSettings mqttIntegration,
     @JsonKey(defaultValue: FaceRecognitionSettings.withDefaults) required FaceRecognitionSettings faceRecognition,
     @JsonKey(defaultValue: DebugSettings.withDefaults) required DebugSettings debug,
+    @Default([]) List<ExternalSystemCheckSetting> externalSystemChecks,
   }) = _Settings;
 
   factory Settings.withDefaults() => Settings.fromJson({});
@@ -307,6 +308,30 @@ sealed class FaceRecognitionSettings with _$FaceRecognitionSettings implements T
 
   factory FaceRecognitionSettings.fromJson(Map<String, Object?> json) => _$FaceRecognitionSettingsFromJson(json);
 
+  @override
+  Map<String, dynamic> toTomlValue() => toJson();
+
+}
+
+// ///////////////////// //
+// External System Check //
+// ///////////////////// //
+
+@Freezed(fromJson: true, toJson: true)
+sealed class ExternalSystemCheckSetting with _$ExternalSystemCheckSetting implements TomlEncodableValue {
+  
+  const ExternalSystemCheckSetting._();
+
+  const factory ExternalSystemCheckSetting({
+    required String name,
+    required String address,
+    required ExternalSystemCheckType type,
+  }) = _ExternalSystemCheckSetting;
+
+  factory ExternalSystemCheckSetting.withDefaults() => ExternalSystemCheckSetting.fromJson({});
+
+  factory ExternalSystemCheckSetting.fromJson(Map<String, Object?> json) => _$ExternalSystemCheckSettingFromJson(json);
+  
   @override
   Map<String, dynamic> toTomlValue() => toJson();
 

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -327,6 +327,7 @@ sealed class ExternalSystemCheckSetting with _$ExternalSystemCheckSetting implem
     required String name,
     required String address,
     required ExternalSystemCheckType type,
+    @Default(ExternalSystemCheckSeverity.warning) ExternalSystemCheckSeverity severity,
     @Default(true) bool enabled,
   }) = _ExternalSystemCheckSetting;
 

--- a/lib/models/settings.enums.dart
+++ b/lib/models/settings.enums.dart
@@ -258,3 +258,9 @@ enum ExternalSystemCheckType {
   ping,
   http,
 }
+
+enum ExternalSystemCheckSeverity {
+  info,
+  warning,
+  error,
+}

--- a/lib/models/settings.enums.dart
+++ b/lib/models/settings.enums.dart
@@ -253,3 +253,8 @@ enum PrintSize {
   const PrintSize(this.name);
 
 }
+
+enum ExternalSystemCheckType {
+  ping,
+  http,
+}

--- a/lib/models/subsystem.dart
+++ b/lib/models/subsystem.dart
@@ -14,6 +14,8 @@ abstract class SubsystemBase with Store, Logger {
   @readonly
   SubsystemStatus _subsystemStatus = const SubsystemStatus.initial();
 
+  abstract String subsystemName;
+
   // ////////////// //
   // Initialization //
   // ////////////// //

--- a/lib/models/subsystem_status.dart
+++ b/lib/models/subsystem_status.dart
@@ -28,6 +28,7 @@ sealed class SubsystemStatus with _$SubsystemStatus {
   const factory SubsystemStatus.warning({
     required String message,
     @Default({}) ActionMap actions,
+    String? exception,
   }) = SubsystemStatusWarning;
 
   const factory SubsystemStatus.error({

--- a/lib/views/settings_overlay/pages/settings_overlay_view.subsystem_status.dart
+++ b/lib/views/settings_overlay/pages/settings_overlay_view.subsystem_status.dart
@@ -11,6 +11,13 @@ Widget _getSubsystemStatusTab(SettingsOverlayViewModel viewModel, SettingsOverla
           Observer(builder: (_) {
             return Column(
               children: [
+                SettingsNumberEditTile(
+                  icon: FluentIcons.clock,
+                  title: "Check interval (seconds)",
+                  subtitle: "How often to run external system health checks.",
+                  value: () => viewModel.externalSystemCheckIntervalSeconds,
+                  onFinishedEditing: (v) => controller.onExternalSystemCheckIntervalChanged(v),
+                ),
                 for (final check in viewModel.externalSystemChecks)
                   _ExternalSystemCheckTile(
                     check: check,
@@ -71,8 +78,8 @@ class _ExternalSystemCheckTileState extends State<_ExternalSystemCheckTile> {
 
   Future<void> _refreshStatus() async {
     setState(() => _loading = true);
-    final manager = ExternalSystemStatusManager([
-      ExternalSystemCheck(
+    final manager = ExternalSystemStatusManager(checks: [
+      ExternalSystemCheckSetting(
         name: widget.check.name,
         address: widget.check.address,
         type: widget.check.type == ExternalSystemCheckType.ping
@@ -97,12 +104,21 @@ class _ExternalSystemCheckTileState extends State<_ExternalSystemCheckTile> {
   @override
   Widget build(BuildContext context) {
     return Card(
+      padding: EdgeInsets.zero,
+      margin: const EdgeInsets.symmetric(vertical: 1),
       child: ListTile(
-        leading: SubsystemStatusIcon(status: _statusIconData),
+        // contentPadding: EdgeInsets.zero,
+        leading: Row(
+          children: [
+            SubsystemStatusIcon(status: _statusIconData),
+            SizedBox(width: 6), // Add some spacing between icon and text
+          ],
+        ),
         title: Text(widget.check.name),
         subtitle: Text('${widget.check.type.name.toUpperCase()} - ${widget.check.address}'),
         trailing: Row(
           mainAxisSize: MainAxisSize.min,
+          spacing: 4,
           children: [
             Tooltip(
               message: 'Enable/Disable',
@@ -111,6 +127,7 @@ class _ExternalSystemCheckTileState extends State<_ExternalSystemCheckTile> {
                 onChanged: (v) => setState(() => widget.onEdit(widget.check.copyWith(enabled: v))),
               )
             ),
+            SizedBox(width: 2),
             Tooltip(
               message: 'Refresh',
               child: IconButton(

--- a/lib/views/settings_overlay/pages/settings_overlay_view.subsystem_status.dart
+++ b/lib/views/settings_overlay/pages/settings_overlay_view.subsystem_status.dart
@@ -1,8 +1,256 @@
 part of '../settings_overlay_view.dart';
 
-Widget _getSubsystemStatusTab(SettingsOverlayViewModel viewModel, SettingsOverlayController controller) {
+Widget _getSubsystemStatusTab(SettingsOverlayViewModel viewModel, SettingsOverlayController controller, BuildContext context) {
   return SettingsPage(
     title: "Subsystem status",
-    blocks: [SubsystemStatusList()],
+    blocks: [
+      SubsystemStatusList(),
+      SettingsSection(
+        title: "External System Health Checks",
+        settings: [
+          Observer(builder: (_) {
+            return Column(
+              children: [
+                for (final check in viewModel.externalSystemChecks)
+                  _ExternalSystemCheckTile(
+                    check: check,
+                    onEdit: (updated) {
+                      final checks = [...viewModel.externalSystemChecks];
+                      final idx = checks.indexOf(check);
+                      if (idx != -1) {
+                        checks[idx] = updated;
+                        controller.onExternalSystemChecksChanged(checks);
+                      }
+                    },
+                    onDelete: () {
+                      final checks = [...viewModel.externalSystemChecks]..remove(check);
+                      controller.onExternalSystemChecksChanged(checks);
+                    },
+                  ),
+                SizedBox(height: 16),
+                FilledButton(
+                  child: const Text("+ Add check"),
+                  onPressed: () {
+                    // Show dialog to add new check
+                    showDialog(
+                      barrierDismissible: true,
+                      context: context,
+                      builder: (ctx) => _ExternalSystemCheckEditDialog(
+                        onSave: (newCheck) {
+                          final checks = [...viewModel.externalSystemChecks, newCheck];
+                          controller.onExternalSystemChecksChanged(checks);
+                          Navigator.of(ctx).pop();
+                        },
+                      ),
+                    );
+                  },
+                ),
+              ],
+            );
+          }),
+        ],
+      ),
+    ],
   );
+}
+
+class _ExternalSystemCheckTile extends StatefulWidget {
+  final ExternalSystemCheckSetting check;
+  final ValueChanged<ExternalSystemCheckSetting> onEdit;
+  final VoidCallback onDelete;
+
+  const _ExternalSystemCheckTile({required this.check, required this.onEdit, required this.onDelete});
+
+  @override
+  State<_ExternalSystemCheckTile> createState() => _ExternalSystemCheckTileState();
+}
+
+class _ExternalSystemCheckTileState extends State<_ExternalSystemCheckTile> {
+  ExternalSystemStatus? _status;
+  bool _loading = false;
+
+  Future<void> _refreshStatus() async {
+    setState(() => _loading = true);
+    final manager = ExternalSystemStatusManager([
+      ExternalSystemCheck(
+        name: widget.check.name,
+        address: widget.check.address,
+        type: widget.check.type == ExternalSystemCheckType.ping
+            ? ExternalSystemCheckType.ping
+            : ExternalSystemCheckType.http,
+      ),
+    ]);
+    final statuses = await manager.runAllChecks();
+    setState(() {
+      _status = statuses.first;
+      _loading = false;
+    });
+  }
+
+  SubsystemStatus get _statusIconData {
+    if (_status == null) return const SubsystemStatus.initial();
+    return _status?.isHealthy == true
+      ? const SubsystemStatus.ok()
+      : SubsystemStatus.error(message: _status?.error ?? "Unknown error");
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: ListTile(
+        leading: SubsystemStatusIcon(status: _statusIconData),
+        title: Text(widget.check.name),
+        subtitle: Text('${widget.check.type.name.toUpperCase()} - ${widget.check.address}'),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Tooltip(
+              message: 'Enable/Disable',
+              child: ToggleSwitch(
+                checked: widget.check.enabled,
+                onChanged: (v) => setState(() => widget.onEdit(widget.check.copyWith(enabled: v))),
+              )
+            ),
+            Tooltip(
+              message: 'Refresh',
+              child: IconButton(
+                icon: _loading ? SizedBox.square(dimension: 20 , child: const ProgressRing(strokeWidth: 3,)) : const Icon(FluentIcons.refresh),
+                onPressed: _loading ? null : _refreshStatus,
+              ),
+            ),
+            Tooltip(
+              message: 'Edit',
+              child: IconButton(
+                icon: const Icon(FluentIcons.edit),
+                onPressed: () {
+                  showDialog(
+                    barrierDismissible: true,
+                    context: context,
+                    builder: (ctx) => _ExternalSystemCheckEditDialog(
+                      initial: widget.check,
+                      onSave: (updated) {
+                        widget.onEdit(updated);
+                        Navigator.of(ctx).pop();
+                      },
+                    ),
+                  );
+                },
+              ),
+            ),
+            Tooltip(
+              message: 'Delete',
+              child: IconButton(
+                icon: const Icon(FluentIcons.delete),
+                onPressed: widget.onDelete,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ExternalSystemCheckEditDialog extends StatefulWidget {
+  final ExternalSystemCheckSetting? initial;
+  final ValueChanged<ExternalSystemCheckSetting> onSave;
+
+  const _ExternalSystemCheckEditDialog({this.initial, required this.onSave});
+
+  @override
+  State<_ExternalSystemCheckEditDialog> createState() => _ExternalSystemCheckEditDialogState();
+}
+
+class _ExternalSystemCheckEditDialogState extends State<_ExternalSystemCheckEditDialog> {
+  late TextEditingController _nameController;
+  late TextEditingController _addressController;
+  ExternalSystemCheckType _type = ExternalSystemCheckType.ping;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: widget.initial?.name ?? '');
+    _addressController = TextEditingController(text: widget.initial?.address ?? '');
+    _type = widget.initial?.type ?? ExternalSystemCheckType.ping;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ContentDialog(
+      title: const Text('External System Check'),
+      content: Column(
+        spacing: 8,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            spacing: 8,
+            children: [
+              Expanded(
+                child: Text('Name', style: FluentTheme.of(context).typography.bodyStrong),
+              ),
+              Expanded(
+                flex: 2,
+                child: TextBox(
+                  controller: _nameController,
+                  placeholder: 'Name',
+                ),
+              ),
+            ],
+          ),
+          Row(
+            spacing: 8,
+            children: [
+              Expanded(
+                child: Text('Address', style: FluentTheme.of(context).typography.bodyStrong),
+              ),
+              Expanded(
+                flex: 2,
+                child: TextBox(
+                  controller: _addressController,
+                  placeholder: 'Address (IP/hostname or URL)',
+                ),
+              ),
+            ],
+          ),
+          Row(
+            spacing: 8,
+            children: [
+              Expanded(
+                child: Text('Type', style: FluentTheme.of(context).typography.bodyStrong),
+              ),
+              Expanded(
+                flex: 2,
+                child: ComboBox<ExternalSystemCheckType>(
+                  value: _type,
+                  items: ExternalSystemCheckType.values
+                      .map((t) => ComboBoxItem(value: t, child: Text(t.name)))
+                      .toList(),
+                  onChanged: (t) => setState(() => _type = t ?? ExternalSystemCheckType.ping),
+                  // header: 'Type',
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+      actions: [
+        Button(
+          child: const Text('Cancel'),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        FilledButton(
+          child: const Text('Save'),
+          onPressed: () {
+            widget.onSave(
+              ExternalSystemCheckSetting(
+                name: _nameController.text,
+                address: _addressController.text,
+                type: _type,
+              ),
+            );
+          },
+        ),
+      ],
+    );
+  }
 }

--- a/lib/views/settings_overlay/pages/settings_overlay_view.subsystem_status.dart
+++ b/lib/views/settings_overlay/pages/settings_overlay_view.subsystem_status.dart
@@ -18,7 +18,7 @@ Widget _getSubsystemStatusTab(SettingsOverlayViewModel viewModel, SettingsOverla
                   value: () => viewModel.externalSystemCheckIntervalSeconds,
                   onFinishedEditing: (v) => controller.onExternalSystemCheckIntervalChanged(v),
                 ),
-                for (final (index, status) in getIt<ExternalSystemStatusManager>().statuses.indexed)
+                for (final (index, status) in getIt<ExternalSystemStatusManager>().systems.indexed)
                   ExternalSystemCheckTile(
                     sysStatus: status,
                     onEdit: (updated) {

--- a/lib/views/settings_overlay/pages/settings_overlay_view.subsystem_status.dart
+++ b/lib/views/settings_overlay/pages/settings_overlay_view.subsystem_status.dart
@@ -82,6 +82,7 @@ class ExternalSystemCheckTile extends StatelessWidget {
 
   String? get _exception => switch (_status) {
         SubsystemStatusError(:final message, :final exception) => '$message\nException text: $exception',
+        SubsystemStatusWarning(:final message, :final exception) => '$message\nException text: $exception',
         _ => null,
       };
 
@@ -173,6 +174,7 @@ class _ExternalSystemCheckEditDialogState extends State<_ExternalSystemCheckEdit
   late TextEditingController _nameController;
   late TextEditingController _addressController;
   ExternalSystemCheckType _type = ExternalSystemCheckType.ping;
+  ExternalSystemCheckSeverity _severity = ExternalSystemCheckSeverity.warning;
 
   @override
   void initState() {
@@ -180,6 +182,7 @@ class _ExternalSystemCheckEditDialogState extends State<_ExternalSystemCheckEdit
     _nameController = TextEditingController(text: widget.initial?.name ?? '');
     _addressController = TextEditingController(text: widget.initial?.address ?? '');
     _type = widget.initial?.type ?? ExternalSystemCheckType.ping;
+    _severity = widget.initial?.severity ?? ExternalSystemCheckSeverity.warning;
   }
 
   @override
@@ -234,7 +237,24 @@ class _ExternalSystemCheckEditDialogState extends State<_ExternalSystemCheckEdit
                       .map((t) => ComboBoxItem(value: t, child: Text(t.name)))
                       .toList(),
                   onChanged: (t) => setState(() => _type = t ?? ExternalSystemCheckType.ping),
-                  // header: 'Type',
+                ),
+              ),
+            ],
+          ),
+          Row(
+            spacing: 8,
+            children: [
+              Expanded(
+                child: Text('Severity', style: FluentTheme.of(context).typography.bodyStrong),
+              ),
+              Expanded(
+                flex: 2,
+                child: ComboBox<ExternalSystemCheckSeverity>(
+                  value: _severity,
+                  items: ExternalSystemCheckSeverity.values
+                      .map((t) => ComboBoxItem(value: t, child: Text(t.name)))
+                      .toList(),
+                  onChanged: (t) => setState(() => _severity = t ?? ExternalSystemCheckSeverity.warning),
                 ),
               ),
             ],
@@ -254,6 +274,7 @@ class _ExternalSystemCheckEditDialogState extends State<_ExternalSystemCheckEdit
                 name: _nameController.text,
                 address: _addressController.text,
                 type: _type,
+                severity: _severity
               ),
             );
           },

--- a/lib/views/settings_overlay/settings_overlay_controller.dart
+++ b/lib/views/settings_overlay/settings_overlay_controller.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:momento_booth/main.dart';
+import 'package:momento_booth/managers/external_system_status_manager.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/managers/sfx_manager.dart';
 import 'package:momento_booth/models/maker_note_data.dart';
@@ -613,11 +614,15 @@ class SettingsOverlayController extends ScreenControllerBase<SettingsOverlayView
   
   void onExternalSystemChecksChanged(List<ExternalSystemCheckSetting> checks) {
     viewModel.updateSettings((settings) => settings.copyWith(externalSystemChecks: checks));
+    // Reinitialize the ExternalSystemStatusManager to apply the new checks.
+    getIt<ExternalSystemStatusManager>().initialize();
   }
 
   void onExternalSystemCheckIntervalChanged(int? interval) {
     if (interval != null) {
       viewModel.updateSettings((settings) => settings.copyWith(externalSystemCheckIntervalSeconds: interval));
+      // Reinitialize the ExternalSystemStatusManager to apply the new interval.
+      getIt<ExternalSystemStatusManager>().initialize();
     }
   }
 

--- a/lib/views/settings_overlay/settings_overlay_controller.dart
+++ b/lib/views/settings_overlay/settings_overlay_controller.dart
@@ -615,6 +615,12 @@ class SettingsOverlayController extends ScreenControllerBase<SettingsOverlayView
     viewModel.updateSettings((settings) => settings.copyWith(externalSystemChecks: checks));
   }
 
+  void onExternalSystemCheckIntervalChanged(int? interval) {
+    if (interval != null) {
+      viewModel.updateSettings((settings) => settings.copyWith(externalSystemCheckIntervalSeconds: interval));
+    }
+  }
+
   void onFaceRecognitionEnableChanged(bool? enable) {
     if (enable != null) {
       viewModel.updateSettings((settings) => settings.copyWith.faceRecognition(enable: enable));

--- a/lib/views/settings_overlay/settings_overlay_controller.dart
+++ b/lib/views/settings_overlay/settings_overlay_controller.dart
@@ -610,6 +610,10 @@ class SettingsOverlayController extends ScreenControllerBase<SettingsOverlayView
       viewModel.updateSettings((settings) => settings.copyWith.mqttIntegration(homeAssistantComponentId: homeAssistantComponentId, enable: false));
     }
   }
+  
+  void onExternalSystemChecksChanged(List<ExternalSystemCheckSetting> checks) {
+    viewModel.updateSettings((settings) => settings.copyWith(externalSystemChecks: checks));
+  }
 
   void onFaceRecognitionEnableChanged(bool? enable) {
     if (enable != null) {

--- a/lib/views/settings_overlay/settings_overlay_controller.dart
+++ b/lib/views/settings_overlay/settings_overlay_controller.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:momento_booth/main.dart';
-import 'package:momento_booth/managers/external_system_status_manager.dart';
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/managers/sfx_manager.dart';
 import 'package:momento_booth/models/maker_note_data.dart';

--- a/lib/views/settings_overlay/settings_overlay_controller.dart
+++ b/lib/views/settings_overlay/settings_overlay_controller.dart
@@ -614,15 +614,11 @@ class SettingsOverlayController extends ScreenControllerBase<SettingsOverlayView
   
   void onExternalSystemChecksChanged(List<ExternalSystemCheckSetting> checks) {
     viewModel.updateSettings((settings) => settings.copyWith(externalSystemChecks: checks));
-    // Reinitialize the ExternalSystemStatusManager to apply the new checks.
-    getIt<ExternalSystemStatusManager>().initialize();
   }
 
   void onExternalSystemCheckIntervalChanged(int? interval) {
     if (interval != null) {
       viewModel.updateSettings((settings) => settings.copyWith(externalSystemCheckIntervalSeconds: interval));
-      // Reinitialize the ExternalSystemStatusManager to apply the new interval.
-      getIt<ExternalSystemStatusManager>().initialize();
     }
   }
 

--- a/lib/views/settings_overlay/settings_overlay_view.dart
+++ b/lib/views/settings_overlay/settings_overlay_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart' show ScaffoldMessenger;
 import 'package:flutter/services.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:intl/intl.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:momento_booth/main.dart';
 import 'package:momento_booth/managers/external_system_status_manager.dart';

--- a/lib/views/settings_overlay/settings_overlay_view.dart
+++ b/lib/views/settings_overlay/settings_overlay_view.dart
@@ -5,10 +5,12 @@ import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:momento_booth/main.dart';
+import 'package:momento_booth/managers/external_system_status_manager.dart';
 import 'package:momento_booth/managers/mqtt_manager.dart';
 import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/managers/stats_manager.dart';
 import 'package:momento_booth/models/settings.dart';
+import 'package:momento_booth/models/subsystem_status.dart';
 import 'package:momento_booth/repositories/secrets/secrets_repository.dart';
 import 'package:momento_booth/utils/environment_info.dart';
 import 'package:momento_booth/views/base/screen_view_base.dart';
@@ -145,7 +147,7 @@ class SettingsOverlayView extends ScreenViewBase<SettingsOverlayViewModel, Setti
                   key: ValueKey(SettingsPageKey.subsystemStatus),
                   icon: const Icon(LucideIcons.messageSquareWarning),
                   title: const Text("Subsystem status"),
-                  body: Builder(builder: (_) => _getSubsystemStatusTab(viewModel, controller)),
+                  body: Builder(builder: (context) => _getSubsystemStatusTab(viewModel, controller, context)),
                   infoBadge: SubsystemStatusIcon(status: viewModel.badgeStatus),
                 ),
                 PaneItem(

--- a/lib/views/settings_overlay/settings_overlay_view_model.dart
+++ b/lib/views/settings_overlay/settings_overlay_view_model.dart
@@ -241,6 +241,7 @@ abstract class SettingsOverlayViewModelBase extends ScreenViewModelBase with Sto
   String get mqttIntegrationHomeAssistantDiscoveryTopicPrefixSetting => getIt<SettingsManager>().settings.mqttIntegration.homeAssistantDiscoveryTopicPrefix;
   String get mqttIntegrationHomeAssistantComponentIdSetting => getIt<SettingsManager>().settings.mqttIntegration.homeAssistantComponentId;
   List<ExternalSystemCheckSetting> get externalSystemChecks => getIt<SettingsManager>().settings.externalSystemChecks;
+  int get externalSystemCheckIntervalSeconds => getIt<SettingsManager>().settings.externalSystemCheckIntervalSeconds;
   bool get faceRecognitionEnabled => getIt<SettingsManager>().settings.faceRecognition.enable;
   String get faceRecognitionServerUrlSetting => getIt<SettingsManager>().settings.faceRecognition.serverUrl;
   bool get debugShowFpsCounter => getIt<SettingsManager>().settings.debug.showFpsCounter;

--- a/lib/views/settings_overlay/settings_overlay_view_model.dart
+++ b/lib/views/settings_overlay/settings_overlay_view_model.dart
@@ -240,6 +240,7 @@ abstract class SettingsOverlayViewModelBase extends ScreenViewModelBase with Sto
   bool get mqttIntegrationEnableHomeAssistantDiscoverySetting => getIt<SettingsManager>().settings.mqttIntegration.enableHomeAssistantDiscovery;
   String get mqttIntegrationHomeAssistantDiscoveryTopicPrefixSetting => getIt<SettingsManager>().settings.mqttIntegration.homeAssistantDiscoveryTopicPrefix;
   String get mqttIntegrationHomeAssistantComponentIdSetting => getIt<SettingsManager>().settings.mqttIntegration.homeAssistantComponentId;
+  List<ExternalSystemCheckSetting> get externalSystemChecks => getIt<SettingsManager>().settings.externalSystemChecks;
   bool get faceRecognitionEnabled => getIt<SettingsManager>().settings.faceRecognition.enable;
   String get faceRecognitionServerUrlSetting => getIt<SettingsManager>().settings.faceRecognition.serverUrl;
   bool get debugShowFpsCounter => getIt<SettingsManager>().settings.debug.showFpsCounter;

--- a/lib/views/settings_overlay/settings_overlay_view_model.dart
+++ b/lib/views/settings_overlay/settings_overlay_view_model.dart
@@ -6,6 +6,7 @@ import 'package:momento_booth/hardware_control/gphoto2_camera.dart';
 import 'package:momento_booth/hardware_control/live_view_streaming/nokhwa_camera.dart';
 import 'package:momento_booth/hardware_control/printing/cups_client.dart';
 import 'package:momento_booth/main.dart';
+import 'package:momento_booth/managers/external_system_status_manager.dart';
 import 'package:momento_booth/managers/project_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/models/print_queue_info.dart';
@@ -82,11 +83,15 @@ abstract class SettingsOverlayViewModelBase extends ScreenViewModelBase with Sto
   List<ComboBoxItem<String>> gPhoto2Cameras = List<ComboBoxItem<String>>.empty();
 
   SubsystemStatus get badgeStatus {
-    if (getIt<ObservableList<Subsystem>>().any((s) => s.subsystemStatus is SubsystemStatusError)) {
+    final subsystemList = getIt<ObservableList<Subsystem>>().map((s) => s.subsystemStatus).toList();
+    final externalSystemList = getIt<ExternalSystemStatusManager>().systemStatuses;
+    final checkList = subsystemList + externalSystemList;
+
+    if (checkList.any((s) => s is SubsystemStatusError)) {
       return const SubsystemStatus.error(message: '');
-    } else if (getIt<ObservableList<Subsystem>>().any((s) => s.subsystemStatus is SubsystemStatusWarning)) {
+    } else if (checkList.any((s) => s is SubsystemStatusWarning)) {
       return const SubsystemStatus.warning(message: '');
-    } else if (getIt<ObservableList<Subsystem>>().any((s) => s.subsystemStatus is SubsystemStatusBusy)) {
+    } else if (checkList.any((s) => s is SubsystemStatusBusy)) {
       return const SubsystemStatus.busy(message: '');
     } else {
       return const SubsystemStatus.ok();


### PR DESCRIPTION
The correct functioning of the photobooth set-up is often not only reliant on the MomentoBooth software itself, but also on other systems or services. Therefore, this PR introduces a health check mechanism for external systems.

In the **subsystem status** page of the settings, you can now set up health monitors for external systems. Checking is supported through **ping** and **HTTP request**. These are executed by a new external system status manager. For each check, you can specify a severity and disable it if it is not relevant at that moment in time.

The notifications manager had a little makeover to display notifications (called InfoBar by FluentUI) for all subsystems and external systems, ordered by severity.