### PR TITLE
Improve print job names

### DIFF
--- a/lib/hardware_control/printing/printing_system_client.dart
+++ b/lib/hardware_control/printing/printing_system_client.dart
@@ -26,9 +26,10 @@ abstract class PrintingSystemClient with Logger {
       if (++lastUsedPrinterIndex >= printers.length) lastUsedPrinterIndex = 0;
       final PrintQueueInfo printer = printers[lastUsedPrinterIndex];
 
-      logDebug("Printing copy #${i+1} with printer #${lastUsedPrinterIndex + 1} [${printer.name}]");
+      logDebug("Printing $taskName at ${printSize.name}, copy #${i+1} / $copies with printer #${lastUsedPrinterIndex + 1} [${printer.name}]");
 
-      await printPdfToQueue(printer.id, taskName, pdfData, printSize: printSize);
+      final String jobName = "$taskName | ${printSize.name} | copy ${i+1} / $copies";
+      await printPdfToQueue(printer.id, jobName, pdfData, printSize: printSize);
 
       getIt<StatsManager>().addPrintedPhoto(size: printSize);
     }

--- a/lib/managers/photos_manager.dart
+++ b/lib/managers/photos_manager.dart
@@ -48,12 +48,18 @@ abstract class PhotosManagerBase with Store, Logger {
 
   Iterable<PhotoCapture> get chosenPhotos => chosen.map((choice) => photos[choice]);
 
+  File? _lastPhotoFile;
+  File? get lastPhotoFile => _lastPhotoFile;
+
   @action
   void reset({bool advance = true}) {
     photos.clear();
     chosen.clear();
     captureMode = CaptureMode.single;
-    if (advance) photoNumber++;
+    if (advance) {
+      photoNumber++;
+      _lastPhotoFile = null;
+    }
   }
 
   @action
@@ -66,7 +72,9 @@ abstract class PhotosManagerBase with Store, Logger {
     final fileExtension = getIt<SettingsManager>().settings.output.exportFormat.name.toLowerCase();
     final filePath = join(outputDir.path, '$baseName-${photoNumber.toString().padLeft(4, '0')}.$fileExtension');
     if (advance) photoNumber++;
-    return await writeBytesToFileLocked(filePath, outputImage!);
+    final f = await writeBytesToFileLocked(filePath, outputImage!);
+    _lastPhotoFile = f;
+    return f;
   }
 
   @action

--- a/lib/views/photo_booth_screen/screens/share_screen/share_screen_controller.dart
+++ b/lib/views/photo_booth_screen/screens/share_screen/share_screen_controller.dart
@@ -107,7 +107,8 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> w
 
     // Get photo and print it.
     final pdfData = await getIt<PhotosManager>().getOutputPDF(size);
-    String jobName = viewModel.file != null ? path.basenameWithoutExtension(viewModel.file!.path) : "MomentoBooth Picture";
+    final lastFile = getIt<PhotosManager>().lastPhotoFile;
+    String jobName = lastFile != null ? path.basenameWithoutExtension(lastFile.path) : "MomentoBooth Picture";
 
     bool success = false;
     try {

--- a/lib/views/photo_booth_screen/screens/share_screen/share_screen_view_model.dart
+++ b/lib/views/photo_booth_screen/screens/share_screen/share_screen_view_model.dart
@@ -66,7 +66,7 @@ abstract class ShareScreenViewModelBase extends ScreenViewModelBase with Store {
   String get backText => captureMode == CaptureMode.single ? localizations.shareScreenRetakeButton : localizations.shareScreenChangeButton;
 
   Future<void> uploadPhotoToSend() async {
-    _file ??= await getIt<PhotosManager>().getOutputImageAsTempFile();
+    _file ??= getIt<PhotosManager>().lastPhotoFile ?? await getIt<PhotosManager>().getOutputImageAsTempFile();
     final ext = getIt<SettingsManager>().settings.output.exportFormat.name.toLowerCase();
 
     logDebug("Uploading ${_file!.path}");


### PR DESCRIPTION
Very simple PR, should create some insight into potential printing issues.

The name of the image is correctly acquired in the share screen. It was already working fine in the photo details screen and manual collage screen.
The format for the job name is now `MomentoBooth-image-0005 | Normal print size | copy 1 / 5`. More detail is also logged as debug info.

Ideally, we would also acquire the job ID and print it.