### PR TITLE
Refactor initialization for better observability

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,23 +4,10 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:get_it/get_it.dart';
-import 'package:mobx/mobx.dart';
-import 'package:momento_booth/app.dart';
-import 'package:momento_booth/extensions/get_it_extension.dart';
-import 'package:momento_booth/managers/_all.dart';
-import 'package:momento_booth/managers/external_system_status_manager.dart';
-import 'package:momento_booth/models/_all.dart';
-import 'package:momento_booth/models/project_data.dart';
-import 'package:momento_booth/models/subsystem.dart';
-import 'package:momento_booth/repositories/_all.dart';
-import 'package:momento_booth/src/rust/api/initialization.dart';
-import 'package:momento_booth/src/rust/frb_generated.dart';
-import 'package:momento_booth/src/rust/models/logging.dart';
-import 'package:momento_booth/utils/environment_info.dart';
-import 'package:momento_booth/utils/file_utils.dart';
+import 'package:momento_booth/managers/app_init_manager.dart';
+import 'package:momento_booth/momento_booth_app.dart';
 import 'package:path/path.dart' as path;
 import 'package:sentry_flutter/sentry_flutter.dart';
-import 'package:talker/talker.dart';
 
 final GetIt getIt = GetIt.instance;
 
@@ -28,12 +15,12 @@ void main(List<String> arguments) async {
   SentryWidgetsFlutterBinding.ensureInitialized();
 
   var parser = ArgParser()
-  ..addFlag("fullscreen", abbr: 'f', help: 'Run in fullscreen mode', defaultsTo: false)
-  ..addOption("open", abbr: 'o', help: 'Open given directory as a project');
-  final args = parser.parse(arguments);
-
-  // This can be unawaited, as onboarding flow will keep user from entering core functionality while this is still ongoing.
-  unawaited(_initializeApp(args));
+    ..addFlag("fullscreen", abbr: 'f', help: 'Run in fullscreen mode', defaultsTo: false)
+    ..addOption("open", abbr: 'o', help: 'Open given directory as a project');
+  getIt
+    ..registerSingleton(parser.parse(arguments))
+    ..registerSingleton(AppInitManager());
+  unawaited(getIt<AppInitManager>().initializeApp());
 
   String sentryDsn = await _resolveSentryDsnOverride() ?? const String.fromEnvironment("SENTRY_DSN", defaultValue: '');
   await SentryFlutter.init(
@@ -44,7 +31,7 @@ void main(List<String> arguments) async {
         ..environment = const String.fromEnvironment("SENTRY_ENVIRONMENT", defaultValue: 'Development')
         ..release = const String.fromEnvironment("SENTRY_RELEASE", defaultValue: 'Development');
     },
-    appRunner: () => runApp(const App()),
+    appRunner: () => runApp(const MomentoBoothApp()),
   );
 }
 
@@ -55,91 +42,4 @@ Future<String?> _resolveSentryDsnOverride() async {
   File sentryDsnOverrideFile = File(possibleSentryDsnOverridePath);
   if (!sentryDsnOverrideFile.existsSync()) return null;
   return (await sentryDsnOverrideFile.readAsString()).trim();
-}
-
-Future<void> _initializeApp(ArgResults args) async {
-  getIt
-    ..enableRegisteringMultipleInstancesOfOneType()
-
-    // Log
-    ..registerSingleton(Talker(settings: TalkerSettings()))
-    ..registerSingleton(ObservableList<Subsystem>())
-
-    // Repositories
-    ..registerSingleton<SecretsRepository>(const SecureStorageSecretsRepository())
-
-    // Managers
-    ..registerManager(StatsManager())
-    ..registerManager(ProjectManager())
-    ..registerManager(SfxManager())
-    ..registerManager(SettingsManager())
-    ..registerManager(WindowManager())
-    ..registerManager(LiveViewManager())
-    ..registerManager(MqttManager())
-    ..registerManager(NotificationsManager())
-    ..registerManager(PrintingManager())
-    ..registerManager(PhotosManager())
-    ..registerManager(ExternalSystemStatusManager());
-
-  await RustLib.init();
-  _initializeLog();
-  await initializeLibrary();
-
-  await initializeEnvironmentInfo();
-
-  getIt
-    ..registerSingleton<SerialiableRepository<Settings>>(
-      TomlSerializableRepository(path.join(appDataPath, "Settings.toml"), Settings.fromJson),
-    )
-    ..registerSingleton<SerialiableRepository<Stats>>(
-      TomlSerializableRepository(path.join(appDataPath, "Stats.toml"), Stats.fromJson),
-    )
-    ..registerSingleton<SerialiableRepository<ProjectsList>>(
-      TomlSerializableRepository(path.join(appDataPath, "Projects.toml"), ProjectsList.fromJson),
-    );
-
-  await getIt<SettingsManager>().initializeSafe();
-  await _createPathsSafe();
-
-  await getIt<StatsManager>().initializeSafe();
-  await getIt<ProjectManager>().initializeSafe();
-  // Open a project if a directory is given
-  // TODO decide what to do if the folder does not exist yet.
-  if (args.option("open") != null)  {
-    await getIt<ProjectManager>().open(args.option("open")!);
-  }
-  await getIt<WindowManager>().initializeSafe();
-  if (args.flag("fullscreen")) {
-    getIt<WindowManager>().setFullscreen(true);
-  }
-  await getIt<LiveViewManager>().initializeSafe();
-  await getIt<MqttManager>().initializeSafe();
-  await getIt<SfxManager>().initializeSafe();
-  await getIt<PrintingManager>().initializeSafe();
-  getIt<NotificationsManager>().initialize();
-  getIt<ExternalSystemStatusManager>().initialize();
-}
-
-void _initializeLog() {
-  Talker talker = getIt<Talker>();
-  initializeLog().listen((msg) {
-    LogLevel logLevel = switch (msg.logLevel) {
-      Level.error => LogLevel.error,
-      Level.warn => LogLevel.warning,
-      Level.info => LogLevel.info,
-      Level.debug => LogLevel.debug,
-      Level.trace => LogLevel.verbose,
-    };
-    talker.log("Lib: ${msg.lbl} - ${msg.msg}", logLevel: logLevel);
-  });
-}
-
-Future<void> _createPathsSafe() async {
-  List<String> paths = [
-    getIt<SettingsManager>().settings.hardware.captureLocation,
-  ];
-
-  for (String path in paths) {
-    createPathSafe(path);
-  }
 }

--- a/lib/managers/app_init_manager.dart
+++ b/lib/managers/app_init_manager.dart
@@ -1,0 +1,164 @@
+import 'dart:async';
+
+import 'package:mobx/mobx.dart';
+import 'package:momento_booth/extensions/get_it_extension.dart';
+import 'package:momento_booth/main.dart';
+import 'package:momento_booth/managers/external_system_status_manager.dart';
+import 'package:momento_booth/managers/live_view_manager.dart';
+import 'package:momento_booth/managers/mqtt_manager.dart';
+import 'package:momento_booth/managers/notifications_manager.dart';
+import 'package:momento_booth/managers/photos_manager.dart';
+import 'package:momento_booth/managers/printing_manager.dart';
+import 'package:momento_booth/managers/project_manager.dart';
+import 'package:momento_booth/managers/settings_manager.dart';
+import 'package:momento_booth/managers/sfx_manager.dart';
+import 'package:momento_booth/managers/stats_manager.dart';
+import 'package:momento_booth/managers/window_manager.dart';
+import 'package:momento_booth/models/project_data.dart';
+import 'package:momento_booth/models/settings.dart';
+import 'package:momento_booth/models/stats.dart';
+import 'package:momento_booth/models/subsystem.dart';
+import 'package:momento_booth/repositories/secrets/secrets_repository.dart';
+import 'package:momento_booth/repositories/secrets/secure_storage_secrets_repository.dart';
+import 'package:momento_booth/repositories/serializable/serializable_repository.dart';
+import 'package:momento_booth/repositories/serializable/toml_serializable_repository.dart';
+import 'package:momento_booth/src/rust/api/initialization.dart';
+import 'package:momento_booth/src/rust/frb_generated.dart';
+import 'package:momento_booth/src/rust/models/logging.dart';
+import 'package:momento_booth/utils/environment_info.dart';
+import 'package:momento_booth/utils/file_utils.dart';
+import 'package:path/path.dart' as path;
+import 'package:talker/talker.dart';
+
+part 'app_init_manager.g.dart';
+
+class AppInitManager = AppInitManagerBase with _$AppInitManager;
+
+/// This is the 'root' manager of the MomentoBooth Photobooth app.
+/// It runs the initialization of the application and is responsible for keeping the status.
+abstract class AppInitManagerBase with Store {
+
+  @readonly
+  String _status = 'Initializing...';
+
+  @readonly
+  bool? _isSucceeded;
+
+  @readonly
+  Object? _exception;
+
+  Future<void> initializeApp() async {
+    try {
+      _status = 'Creating instances';
+      getIt
+        ..enableRegisteringMultipleInstancesOfOneType()
+
+        // Log
+        ..registerSingleton(Talker(settings: TalkerSettings()))
+        ..registerSingleton(ObservableList<Subsystem>())
+
+        // Repositories
+        ..registerSingleton<SecretsRepository>(const SecureStorageSecretsRepository())
+
+        // Managers
+        ..registerManager(StatsManager())
+        ..registerManager(ProjectManager())
+        ..registerManager(SfxManager())
+        ..registerManager(SettingsManager())
+        ..registerManager(WindowManager())
+        ..registerManager(LiveViewManager())
+        ..registerManager(MqttManager())
+        ..registerManager(NotificationsManager())
+        ..registerManager(PrintingManager())
+        ..registerManager(PhotosManager())
+        ..registerManager(ExternalSystemStatusManager());
+
+      // ////////////////////////// //
+      // Helper lib and Environment //
+      // ////////////////////////// //
+
+      await _setStatusAndRun('Initializing helper library (FRB)', RustLib.init);
+      _initializeLog();
+      await _setStatusAndRun('Initializing helper library (custom)', initializeLibrary);
+      await _setStatusAndRun('Resolving environment info', initializeEnvironmentInfo);
+
+      // ///////////////// //
+      // TOML repositories //
+      // ///////////////// //
+
+      _status = 'Instantiating TOML repositories';
+      getIt
+        ..registerSingleton<SerialiableRepository<Settings>>(
+          TomlSerializableRepository(path.join(appDataPath, "Settings.toml"), Settings.fromJson),
+        )
+        ..registerSingleton<SerialiableRepository<Stats>>(
+          TomlSerializableRepository(path.join(appDataPath, "Stats.toml"), Stats.fromJson),
+        )
+        ..registerSingleton<SerialiableRepository<ProjectsList>>(
+          TomlSerializableRepository(path.join(appDataPath, "Projects.toml"), ProjectsList.fromJson),
+        );
+
+      // /////////////////////// //
+      // Settings and Statistics //
+      // /////////////////////// //
+
+      await _setStatusAndRun('Initializing settings manager', getIt<SettingsManager>().initializeSafe);
+      await _setStatusAndRun('Creating paths', _createPathsSafe);
+      await _setStatusAndRun('Initializing statistics manager', getIt<StatsManager>().initializeSafe);
+
+      // ////////////// //
+      // Other managers //
+      // ////////////// //
+
+      await _setStatusAndFireAndForget('Initializing project manager', getIt<ProjectManager>().initializeSafe);
+      await _setStatusAndFireAndForget('Initializing window manager', getIt<WindowManager>().initializeSafe);
+      await _setStatusAndFireAndForget('Initializing live view manager', getIt<LiveViewManager>().initializeSafe);
+      await _setStatusAndFireAndForget('Initializing MQTT manager', getIt<MqttManager>().initializeSafe);
+      await _setStatusAndFireAndForget('Initializing SFX manager', getIt<SfxManager>().initializeSafe);
+      await _setStatusAndFireAndForget('Initializing printing manager', getIt<PrintingManager>().initializeSafe);
+      await _setStatusAndRun('Initializing notifications manager', getIt<NotificationsManager>().initialize);
+      await _setStatusAndRun('Initializing external system status manager', getIt<ExternalSystemStatusManager>().initialize);
+
+      _isSucceeded = true;
+    } catch (e) {
+      _exception = e;
+      _isSucceeded = false;
+    }
+  }
+
+  Future<void> _setStatusAndRun(String status, FutureOr<void> Function() func) async {
+    _status = status;
+    await func();
+  }
+
+  Future<void> _setStatusAndFireAndForget(String status, Future<void> Function() func) async {
+    _status = status;
+    await Future.any([
+      func(),
+      Future.delayed(const Duration(seconds: 5)),
+    ]);
+  }
+
+  void _initializeLog() {
+    Talker talker = getIt<Talker>();
+    initializeLog().listen((msg) {
+      LogLevel logLevel = switch (msg.logLevel) {
+        Level.error => LogLevel.error,
+        Level.warn => LogLevel.warning,
+        Level.info => LogLevel.info,
+        Level.debug => LogLevel.debug,
+        Level.trace => LogLevel.verbose,
+      };
+      talker.log("Lib: ${msg.lbl} - ${msg.msg}", logLevel: logLevel);
+    });
+  }
+
+  Future<void> _createPathsSafe() async {
+    List<String> paths = [getIt<SettingsManager>().settings.hardware.captureLocation];
+
+    for (String path in paths) {
+      createPathSafe(path);
+    }
+  }
+
+}

--- a/lib/managers/app_init_manager.dart
+++ b/lib/managers/app_init_manager.dart
@@ -28,6 +28,7 @@ import 'package:momento_booth/src/rust/models/logging.dart';
 import 'package:momento_booth/utils/environment_info.dart';
 import 'package:momento_booth/utils/file_utils.dart';
 import 'package:path/path.dart' as path;
+import 'package:stack_trace/stack_trace.dart';
 import 'package:talker/talker.dart';
 
 part 'app_init_manager.g.dart';
@@ -46,6 +47,9 @@ abstract class AppInitManagerBase with Store {
 
   @readonly
   Object? _exception;
+
+  @readonly
+  Trace? _stackTrace;
 
   Future<void> initializeApp() async {
     try {
@@ -120,9 +124,10 @@ abstract class AppInitManagerBase with Store {
       await _setStatusAndRun('Initializing external system status manager', getIt<ExternalSystemStatusManager>().initialize);
 
       _isSucceeded = true;
-    } catch (e) {
+    } catch (e, s) {
       _exception = e;
       _isSucceeded = false;
+      _stackTrace = Trace.from(s).terse;
     }
   }
 

--- a/lib/managers/project_manager.dart
+++ b/lib/managers/project_manager.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:ui';
 
+import 'package:args/args.dart';
 import 'package:collection/collection.dart';
 import 'package:file_selector/file_selector.dart';
 import 'package:mobx/mobx.dart';
@@ -71,7 +72,10 @@ abstract class ProjectManagerBase extends Subsystem with Store, Logger {
       );
     }
 
-    if (getIt<SettingsManager>().settings.loadLastProject) {
+    final args = getIt<ArgResults>().option("open");
+    if (args != null) {
+      await open(args);
+    } else if (getIt<SettingsManager>().settings.loadLastProject) {
       await openLastProject();
     }
   }

--- a/lib/momento_booth_app.dart
+++ b/lib/momento_booth_app.dart
@@ -26,19 +26,19 @@ import 'package:momento_booth/views/settings_overlay/settings_overlay.dart';
 import 'package:provider/provider.dart';
 import 'package:window_manager/window_manager.dart' show WindowListener, windowManager;
 
-part 'app.hotkeys.dart';
-part 'app.routes.dart';
+part 'momento_booth_app.hotkeys.dart';
+part 'momento_booth_app.routes.dart';
 
-class App extends StatefulWidget {
+class MomentoBoothApp extends StatefulWidget {
 
-  const App({super.key});
+  const MomentoBoothApp({super.key});
 
   @override
-  State<App> createState() => _AppState();
+  State<MomentoBoothApp> createState() => _MomentoBoothAppState();
 
 }
 
-class _AppState extends State<App> with WindowListener {
+class _MomentoBoothAppState extends State<MomentoBoothApp> with WindowListener {
 
   final GoRouter _router = GoRouter(
     routes: [

--- a/lib/momento_booth_app.hotkeys.dart
+++ b/lib/momento_booth_app.hotkeys.dart
@@ -1,4 +1,4 @@
-part of 'app.dart';
+part of 'momento_booth_app.dart';
 
 class _HotkeyResponder extends StatelessWidget {
 

--- a/lib/momento_booth_app.routes.dart
+++ b/lib/momento_booth_app.routes.dart
@@ -1,4 +1,4 @@
-part of 'app.dart';
+part of 'momento_booth_app.dart';
 
 List<RouteBase> _rootRoutes = [
   _onboardingRoute,

--- a/lib/views/components/indicators/onboarding_version_info.dart
+++ b/lib/views/components/indicators/onboarding_version_info.dart
@@ -9,10 +9,13 @@ class OnboardingVersionInfo extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Text(
-      'MomentoBooth ${appVersionInfo.appVersion}\n'
-        'Built with Flutter ${appVersionInfo.flutterVersion}, Rust ${appVersionInfo.rustVersion} (with target ${appVersionInfo.rustTarget})',
-      textAlign: TextAlign.center,
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Text(
+        'MomentoBooth ${appVersionInfo.appVersion}\n'
+          'Built with Flutter ${appVersionInfo.flutterVersion}, Rust ${appVersionInfo.rustVersion}',
+        textAlign: TextAlign.center,
+      ),
     );
   }
 

--- a/lib/views/onboarding_screen/components/wizard_page.dart
+++ b/lib/views/onboarding_screen/components/wizard_page.dart
@@ -7,16 +7,15 @@ import 'package:wizard_router/wizard_router.dart';
 class WizardPage extends StatelessWidget {
 
   final Widget child;
-  final bool showBackAction;
   final bool showNextAction;
 
-  const WizardPage({super.key, this.showBackAction = true, this.showNextAction = true, required this.child});
+  const WizardPage({super.key, this.showNextAction = true, required this.child});
 
   @override
   Widget build(BuildContext context) {
     return Column(
       children: [
-        if (Wizard.of(context).hasPrevious && showBackAction)
+        if (Wizard.of(context).hasPrevious)
           Container(
             alignment: Alignment.topLeft,
             padding: EdgeInsets.only(left: 32, top: 24),

--- a/lib/views/onboarding_screen/components/wizard_page.dart
+++ b/lib/views/onboarding_screen/components/wizard_page.dart
@@ -7,14 +7,16 @@ import 'package:wizard_router/wizard_router.dart';
 class WizardPage extends StatelessWidget {
 
   final Widget child;
+  final bool showBackAction;
+  final bool showNextAction;
 
-  const WizardPage({super.key, required this.child});
+  const WizardPage({super.key, this.showBackAction = true, this.showNextAction = true, required this.child});
 
   @override
   Widget build(BuildContext context) {
     return Column(
       children: [
-        if (Wizard.of(context).hasPrevious)
+        if (Wizard.of(context).hasPrevious && showBackAction)
           Container(
             alignment: Alignment.topLeft,
             padding: EdgeInsets.only(left: 32, top: 24),
@@ -27,7 +29,7 @@ class WizardPage extends StatelessWidget {
         Container(
           alignment: Alignment.bottomRight,
           padding: EdgeInsets.only(right: 32, bottom: 24),
-          child: FilledButton(
+          child: showNextAction ? FilledButton(
             onPressed: () {
               if (Wizard.of(context).hasNext) {
                 Wizard.of(context).next();
@@ -36,7 +38,7 @@ class WizardPage extends StatelessWidget {
               }
             },
             child: Text(Wizard.of(context).hasNext ? "Next step" : "Finish"),
-          ),
+          ) : null,
         ),
       ],
     );

--- a/lib/views/onboarding_screen/onboarding_screen.dart
+++ b/lib/views/onboarding_screen/onboarding_screen.dart
@@ -12,6 +12,7 @@ import 'package:momento_booth/managers/app_init_manager.dart';
 import 'package:momento_booth/utils/environment_info.dart';
 import 'package:momento_booth/views/components/indicators/onboarding_version_info.dart';
 import 'package:momento_booth/views/onboarding_screen/components/onboarding_wizard.dart';
+import 'package:momento_booth/views/onboarding_screen/pages/error_page.dart';
 import 'package:momento_booth/views/onboarding_screen/pages/initialization_page.dart';
 import 'package:momento_booth/views/onboarding_screen/pages/projects_page.dart';
 import 'package:momento_booth/views/onboarding_screen/pages/settings_import_page.dart';
@@ -37,6 +38,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
 
   final WizardController _wizardController = WizardController(routes: {
       '/initialization-page': WizardRoute(builder: (context) => InitializationPage()),
+      '/error-page': WizardRoute(builder: (context) => ErrorPage()),
       '/welcome-page': WizardRoute(builder: (context) => WelcomePage()),
       '/status-page': WizardRoute(builder: (context) => StatusPage()),
       '/settings-import-page': WizardRoute(builder: (context) => SettingsImportPage()),
@@ -60,7 +62,10 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
 
     _autorunDispose = autorun((_) {
       if (getIt<AppInitManager>().isSucceeded == true) {
-        _wizardController.next();
+        _wizardController.routes.remove('/error-page');
+        _wizardController.replace();
+      } else if (getIt<AppInitManager>().isSucceeded == false) {
+        _wizardController.replace();
       }
     });
 

--- a/lib/views/onboarding_screen/pages/error_page.dart
+++ b/lib/views/onboarding_screen/pages/error_page.dart
@@ -1,0 +1,39 @@
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:momento_booth/main.dart';
+import 'package:momento_booth/managers/app_init_manager.dart';
+import 'package:momento_booth/views/onboarding_screen/components/wizard_page.dart';
+
+class ErrorPage extends StatelessWidget {
+
+  const ErrorPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return WizardPage(
+      showNextAction: false,
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          spacing: 8,
+          children: [
+            Text("Error!", style: FluentTheme.of(context).typography.title),
+            Text("A fatal error occured while initializing the application. MomentoBooth cannot continue.\n\nPlease review the exception below, try to resolve the issue then restart the application to try again."),
+            Expanded(child: ListView(
+              children: [
+                Text("Exception", style: FluentTheme.of(context).typography.subtitle),
+                const SizedBox(height: 8),
+                Text(getIt<AppInitManager>().exception?.toString() ?? 'Unknown error'),
+                const SizedBox(height: 16),
+                Text("Stacktrace", style: FluentTheme.of(context).typography.subtitle),
+                const SizedBox(height: 8),
+                Text(getIt<AppInitManager>().stackTrace?.toString() ?? 'Unknown stacktrace'),
+              ],
+            )),
+          ],
+        ),
+      ),
+    );
+  }
+
+}

--- a/lib/views/onboarding_screen/pages/initialization_page.dart
+++ b/lib/views/onboarding_screen/pages/initialization_page.dart
@@ -1,0 +1,35 @@
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
+import 'package:momento_booth/main.dart';
+import 'package:momento_booth/managers/app_init_manager.dart';
+import 'package:momento_booth/views/onboarding_screen/components/wizard_page.dart';
+
+class InitializationPage extends StatelessWidget {
+
+  const InitializationPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return WizardPage(
+      showNextAction: false,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          Observer(
+            builder: (context) {
+              return Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  ProgressRing(),
+                  const SizedBox(height: 16),
+                  Text(getIt<AppInitManager>().status),
+                ],
+              );
+            }
+          ),
+        ],
+      ),
+    );
+  }
+
+}

--- a/lib/views/onboarding_screen/pages/status_page.dart
+++ b/lib/views/onboarding_screen/pages/status_page.dart
@@ -11,7 +11,7 @@ class StatusPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return WizardPage(
       child: Padding(
-        padding: const EdgeInsets.fromLTRB(32, 8, 32, 8),
+        padding: const EdgeInsets.fromLTRB(32, 0, 32, 8),
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [

--- a/lib/views/onboarding_screen/pages/welcome_page.dart
+++ b/lib/views/onboarding_screen/pages/welcome_page.dart
@@ -9,7 +9,6 @@ class WelcomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return WizardPage(
-      showBackAction: false,
       child: Stack(
         fit: StackFit.expand,
         children: [

--- a/lib/views/onboarding_screen/pages/welcome_page.dart
+++ b/lib/views/onboarding_screen/pages/welcome_page.dart
@@ -9,6 +9,7 @@ class WelcomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return WizardPage(
+      showBackAction: false,
       child: Stack(
         fit: StackFit.expand,
         children: [

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1260,7 +1260,7 @@ packages:
     source: hosted
     version: "7.0.0"
   stack_trace:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: stack_trace
       sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,6 +69,7 @@ dependencies:
   talker: 5.0.0
   talker_flutter: 5.0.0
   sentry_flutter: 9.6.0
+  stack_trace: 1.12.1
 
   # Storage
   flutter_secure_storage: 9.2.4


### PR DESCRIPTION
This PR introduces phase 1 of the onboarding improvements for our first stable release.
It moves the initialization logic from `main.dart` into a dedicated `AppInitManager`.

Benefits:

- Initialization is no longer fire-and-forget — its progress and success can now be tracked via the UI.
- Subsystem initialization is capped at 5 seconds. If a subsystem takes longer, the next page of the onboarding UI will indicate which one is still in progress.