### PR TITLE
Add ffsend timeout

### DIFF
--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -187,6 +187,8 @@ sealed class OutputSettings with _$OutputSettings implements TomlEncodableValue 
     @Default(4.0) double resolutionMultiplier,
     @Default(ExportFormat.jpgFormat) ExportFormat exportFormat,
     @Default("https://send.vis.ee/") String firefoxSendServerUrl,
+    @Default(Duration(seconds: 5)) Duration firefoxSendControlCommandTimeout,
+    @Default(Duration(seconds: 15)) Duration firefoxSendTransferTimeout,
   }) = _OutputSettings;
 
   factory OutputSettings.withDefaults() => OutputSettings.fromJson({});

--- a/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_view_model.dart
+++ b/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_view_model.dart
@@ -58,7 +58,13 @@ abstract class PhotoDetailsScreenViewModelBase extends ScreenViewModelBase with 
     logDebug("Uploading ${file!.path}");
 
     String basename = path.basename(file!.path);
-    Stream<FfSendTransferProgress> stream = ffsendUploadFile(filePath: file!.path, hostUrl: ffSendUrl, downloadFilename: basename);
+    Stream<FfSendTransferProgress> stream = ffsendUploadFile(
+      filePath: file!.path,
+      hostUrl: ffSendUrl,
+      downloadFilename: basename,
+      controlCommandTimeout: getIt<SettingsManager>().settings.output.firefoxSendControlCommandTimeout,
+      transferTimeout: getIt<SettingsManager>().settings.output.firefoxSendTransferTimeout,
+    );
 
     _uploadProgress = 0.0;
     _uploadFailed = false;

--- a/lib/views/photo_booth_screen/screens/share_screen/share_screen_view_model.dart
+++ b/lib/views/photo_booth_screen/screens/share_screen/share_screen_view_model.dart
@@ -83,7 +83,13 @@ abstract class ShareScreenViewModelBase extends ScreenViewModelBase with Store {
     // HHmmss string
     DateFormat formatter = DateFormat('HHmmss');
     String filename = "MomentoBooth ${formatter.format(DateTime.now())}.$ext";
-    Stream<FfSendTransferProgress> stream = ffsendUploadFile(filePath: _file!.path, hostUrl: ffSendUrl, downloadFilename: filename);
+    Stream<FfSendTransferProgress> stream = ffsendUploadFile(
+      filePath: _file!.path,
+      hostUrl: ffSendUrl,
+      downloadFilename: filename,
+      controlCommandTimeout: getIt<SettingsManager>().settings.output.firefoxSendControlCommandTimeout,
+      transferTimeout: getIt<SettingsManager>().settings.output.firefoxSendTransferTimeout,
+    );
 
     _uploadProgress = 0.0;
     _uploadFailed = false;

--- a/lib/views/settings_overlay/pages/settings_overlay_view.output.dart
+++ b/lib/views/settings_overlay/pages/settings_overlay_view.output.dart
@@ -20,6 +20,20 @@ Widget _getOutputSettings(SettingsOverlayViewModel viewModel, SettingsOverlayCon
             controller: controller.firefoxSendServerUrlController,
             onFinishedEditing: controller.onFirefoxSendServerUrlChanged,
           ),
+          SettingsNumberEditTile(
+            icon: LucideIcons.timer,
+            title: "Firefox Send control command timeout",
+            subtitle: "The duration (in seconds) a control command is allowed to take",
+            value: () => viewModel.firefoxSendControlCommandTimeoutSetting,
+            onFinishedEditing: controller.onFirefoxSendControlCommandTimeoutChanged,
+          ),
+          SettingsNumberEditTile(
+            icon: LucideIcons.timer,
+            title: "Firefox Send transfer timeout",
+            subtitle: "The duration (in seconds) a picture upload is allowed to take",
+            value: () => viewModel.firefoxSendTransferTimeoutSetting,
+            onFinishedEditing: controller.onFirefoxSendTransferTimeoutChanged,
+          ),
         ],
       ),
       SettingsSection(

--- a/lib/views/settings_overlay/settings_overlay_controller.dart
+++ b/lib/views/settings_overlay/settings_overlay_controller.dart
@@ -461,6 +461,18 @@ class SettingsOverlayController extends ScreenControllerBase<SettingsOverlayView
     }
   }
 
+  void onFirefoxSendControlCommandTimeoutChanged(int? firefoxSendControlCommandTimeout) {
+    if (firefoxSendControlCommandTimeout != null) {
+      viewModel.updateSettings((settings) => settings.copyWith.output(firefoxSendControlCommandTimeout: Duration(seconds: firefoxSendControlCommandTimeout)));
+    }
+  }
+
+  void onFirefoxSendTransferTimeoutChanged(int? firefoxSendTransferTimeout) {
+    if (firefoxSendTransferTimeout != null) {
+      viewModel.updateSettings((settings) => settings.copyWith.output(firefoxSendTransferTimeout: Duration(seconds: firefoxSendTransferTimeout)));
+    }
+  }
+
   void onExportFormatChanged(ExportFormat? exportFormat) {
     if (exportFormat != null) {
       viewModel.updateSettings((settings) => settings.copyWith.output(exportFormat: exportFormat));

--- a/lib/views/settings_overlay/settings_overlay_view_model.dart
+++ b/lib/views/settings_overlay/settings_overlay_view_model.dart
@@ -225,6 +225,8 @@ abstract class SettingsOverlayViewModelBase extends ScreenViewModelBase with Sto
   int get printerQueueWarningThresholdSetting => getIt<SettingsManager>().settings.hardware.printerQueueWarningThreshold;
   String get localFolderSetting => getIt<SettingsManager>().settings.output.localFolder;
   String get firefoxSendServerUrlSetting => getIt<SettingsManager>().settings.output.firefoxSendServerUrl;
+  int get firefoxSendControlCommandTimeoutSetting => getIt<SettingsManager>().settings.output.firefoxSendControlCommandTimeout.inSeconds;
+  int get firefoxSendTransferTimeoutSetting => getIt<SettingsManager>().settings.output.firefoxSendTransferTimeout.inSeconds;
   ExportFormat get exportFormat => getIt<SettingsManager>().settings.output.exportFormat;
   int get jpgQuality => getIt<SettingsManager>().settings.output.jpgQuality;
   double get resolutionMultiplier => getIt<SettingsManager>().settings.output.resolutionMultiplier;

--- a/rust/src/api/ffsend.rs
+++ b/rust/src/api/ffsend.rs
@@ -1,10 +1,11 @@
+use chrono::Duration;
 pub use ipp::model::PrinterState;
 pub use ipp::model::JobState;
 
 use crate::{frb_generated::StreamSink, utils::ffsend_client::{self, FfSendTransferProgress}};
 
-pub fn ffsend_upload_file(host_url: String, file_path: String, download_filename: Option<String>, max_downloads: Option<u8>, expires_after_seconds: Option<u32>, update_sink: StreamSink<FfSendTransferProgress>) {
-    ffsend_client::upload_file(host_url, file_path, download_filename, max_downloads, expires_after_seconds, update_sink)
+pub fn ffsend_upload_file(host_url: String, file_path: String, download_filename: Option<String>, max_downloads: Option<u8>, expires_after_seconds: Option<u32>, update_sink: StreamSink<FfSendTransferProgress>, control_command_timeout: Duration, transfer_timeout: Duration) {
+    ffsend_client::upload_file(host_url, file_path, download_filename, max_downloads, expires_after_seconds, update_sink, control_command_timeout.to_std().unwrap(), transfer_timeout.to_std().unwrap())
 }
 
 pub fn ffsend_delete_file(file_id: String) {


### PR DESCRIPTION
Default timeouts turn out to be way too long (24h for the transfer). This changes them to more sensible defaults and make them configurable using the config file and the UI.