### PR TITLE
Fix Windows library bundle script not bundling libraries

### DIFF
--- a/.github/workflows/pr-ci-app-win-x64.yml
+++ b/.github/workflows/pr-ci-app-win-x64.yml
@@ -143,7 +143,15 @@ jobs:
     - name: Bundle dependencies
       working-directory: ${{ env.DEV_DRIVE }}/momentobooth
       shell: pwsh
-      run: .\windows\bundle_libs.ps1
+      run: |
+        .\windows\bundle_libs.ps1
+
+        $file = Join-Path $env:DEV_DRIVE 'momentobooth\build\windows\x64\runner\Release\libgphoto2-6.dll'
+        if (-not (Test-Path $file)) {
+          Write-Error "Missing file: $file"
+          exit 1
+        }
+        Write-Output "Found: $file"
 
     - name: Compile Inno Setup installer
       shell: pwsh

--- a/.github/workflows/release-win-x64.yml
+++ b/.github/workflows/release-win-x64.yml
@@ -154,7 +154,15 @@ jobs:
     - name: Bundle dependencies
       working-directory: ${{ env.DEV_DRIVE }}/momentobooth
       shell: pwsh
-      run: .\windows\bundle_libs.ps1
+      run: |
+        .\windows\bundle_libs.ps1
+      
+        $file = Join-Path $env:DEV_DRIVE 'momentobooth\build\windows\x64\runner\Release\libgphoto2-6.dll'
+        if (-not (Test-Path $file)) {
+          Write-Error "Missing file: $file"
+          exit 1
+        }
+        Write-Output "Found: $file"
 
     - name: Compile Inno Setup installer
       shell: pwsh

--- a/windows/bundle_libs.ps1
+++ b/windows/bundle_libs.ps1
@@ -1,4 +1,5 @@
-$bundle_script = curl https://raw.githubusercontent.com/momentobooth/mingw-bundledlls/master/mingw-bundledlls
+$bundle_script = (Invoke-WebRequest https://raw.githubusercontent.com/momentobooth/mingw-bundledlls/master/mingw-bundledlls).Content
+
 Write-Output "Running bundling for rust_lib_momento_booth.dll"
 Write-Output $bundle_script | python - --copy build\windows\x64\runner\Release\rust_lib_momento_booth.dll
 if ($LastExitCode -ne 0) { throw "mingw-bundledlls failed with exit code $LastExitCode" }
@@ -12,11 +13,9 @@ Copy-Item $Env:CLANG64_LIB_PATH\libgphoto2\*\*.dll build\windows\x64\runner\Rele
 # Bundle dependency libs.
 Set-Location build\windows\x64\runner\Release\
 $lib_folders = @('libgphoto2_iolibs', 'libgphoto2_camlibs')
-foreach ( $folder in $lib_folders )
-{
+foreach ($folder in $lib_folders) {
   $libs = Get-ChildItem $folder
-  foreach ( $lib in $libs )
-  {
+  foreach ($lib in $libs) {
     Write-Output "Running bundling for $lib"
     Write-Output $bundle_script | python - --copy $lib.fullName
     if ($LastExitCode -ne 0) { throw "mingw-bundledlls failed with exit code $LastExitCode" }
@@ -24,8 +23,7 @@ foreach ( $folder in $lib_folders )
 
   # Now move all libraries to the same folder as the executable (except iolibs and camlibs themselves).
   $files = Get-ChildItem $folder
-  foreach ( $file in $files )
-  {
+  foreach ($file in $files) {
     if ($libs.Name -notcontains $file.Name) {
       Move-Item -Path $file -Destination $file.Directory.Parent.FullName -force
     }


### PR DESCRIPTION
Additionally added a basic check that verifies whether `libgphoto2-6.dll` has been copied over to detect whether the bundle script has done anything.