### PR TITLE
Add per-project toggle to show/hide the gallery

### DIFF
--- a/lib/models/project_settings.dart
+++ b/lib/models/project_settings.dart
@@ -33,6 +33,7 @@ sealed class ProjectSettings with _$ProjectSettings implements TomlEncodableValu
     @Default(CollageMode.userSelection) CollageMode collageMode,
     @Default(Language.noLanguage) Language language,
     @Default([]) List<Language> availableLanguages,
+    @Default(true) bool showGallery,
   }) = _ProjectSettings;
 
   factory ProjectSettings.withDefaults() => ProjectSettings.fromJson({});

--- a/lib/views/photo_booth_screen/photo_booth.menu.dart
+++ b/lib/views/photo_booth_screen/photo_booth.menu.dart
@@ -41,7 +41,8 @@ class MomentoMenuBar extends StatelessWidget {
             MenuFlyoutSubItem(text: Text(localizations.genericSimulateColorVisionDeficiency), items: (_) => _getColorVisionDeficiencyFlyoutItems(localizations), trailing: _shortcut("Ctrl+D")),
             const MenuFlyoutSeparator(),
             MenuFlyoutItem(text: Text(localizations.screensStart), onPressed: () => router.go(StartScreen.defaultRoute), leading: Icon(LucideIcons.play), trailing: _shortcut("Ctrl+H")),
-            MenuFlyoutItem(text: Text(localizations.screensGallery), onPressed: () => router.go(GalleryScreen.defaultRoute), leading: Icon(LucideIcons.images)),
+            if (getIt<ProjectManager>().settings.showGallery)
+              MenuFlyoutItem(text: Text(localizations.screensGallery), onPressed: () => router.go(GalleryScreen.defaultRoute), leading: Icon(LucideIcons.images)),
             MenuFlyoutItem(text: Text(localizations.screensManualCollage), onPressed: () => router.go(ManualCollageScreen.defaultRoute), leading: Icon(LucideIcons.layoutDashboard), trailing: _shortcut("Ctrl+M")),
           ]),
           MenuBarItem(title: localizations.genericHelp, items: [

--- a/lib/views/photo_booth_screen/screens/navigation_screen/navigation_screen_view.dart
+++ b/lib/views/photo_booth_screen/screens/navigation_screen/navigation_screen_view.dart
@@ -41,7 +41,8 @@ class NavigationScreenView extends ScreenViewBase<NavigationScreenViewModel, Nav
                 ] else ...[
                   Expanded(child: _photoButton),
                 ],
-                Expanded(child: _galleryButton),
+                if (viewModel.showGallery)
+                  Expanded(child: _galleryButton),
               ],
             ),
           ),

--- a/lib/views/photo_booth_screen/screens/navigation_screen/navigation_screen_view_model.dart
+++ b/lib/views/photo_booth_screen/screens/navigation_screen/navigation_screen_view_model.dart
@@ -18,6 +18,7 @@ abstract class NavigationScreenViewModelBase extends ScreenViewModelBase with St
   
   bool get enableSingleCapture => getIt<ProjectManager>().settings.enableSingleCapture;
   bool get enableCollageCapture => getIt<ProjectManager>().settings.enableCollageCapture;
+  bool get showGallery => getIt<ProjectManager>().settings.showGallery;
   List<Language> get projectAvailableLanguages => getIt<ProjectManager>().settings.availableLanguages;
 
   @computed

--- a/lib/views/settings_overlay/pages/settings_overlay_view.project.dart
+++ b/lib/views/settings_overlay/pages/settings_overlay_view.project.dart
@@ -77,6 +77,13 @@ Widget _getProjectSettings(SettingsOverlayViewModel viewModel, SettingsOverlayCo
                 value: () => viewModel.projectAvailableLanguagesSetting,
                 onChanged: controller.onProjectAvailableLanguagesChanged,
               ),
+              SettingsToggleTile(
+                icon: LucideIcons.images,
+                title: "Show gallery",
+                subtitle: "If enabled, users can open the gallery to view previously captured photos. When disabled, the gallery button is hidden from the navigation screen and menu.",
+                value: () => viewModel.showGallerySetting,
+                onChanged: controller.onShowGalleryChanged,
+              ),
             ]
           );
         }

--- a/lib/views/settings_overlay/settings_overlay_controller.dart
+++ b/lib/views/settings_overlay/settings_overlay_controller.dart
@@ -214,6 +214,12 @@ class SettingsOverlayController extends ScreenControllerBase<SettingsOverlayView
     }
   }
 
+  void onShowGalleryChanged(bool? showGallery) {
+    if (showGallery != null) {
+      viewModel.updateProjectSettings((settings) => settings.copyWith(showGallery: showGallery));
+    }
+  }
+
   void onEnableWakelockChanged(bool? enableWakelock) {
     if (enableWakelock != null) {
       viewModel.updateSettings((settings) => settings.copyWith(enableWakelock: enableWakelock));

--- a/lib/views/settings_overlay/settings_overlay_view_model.dart
+++ b/lib/views/settings_overlay/settings_overlay_view_model.dart
@@ -221,6 +221,7 @@ abstract class SettingsOverlayViewModelBase extends ScreenViewModelBase with Sto
   Color get primaryColorSetting => getIt<ProjectManager>().settings.primaryColor;
   Language get projectLanguageSetting => getIt<ProjectManager>().settings.language;
   List<Language> get projectAvailableLanguagesSetting => getIt<ProjectManager>().settings.availableLanguages;
+  bool get showGallerySetting => getIt<ProjectManager>().settings.showGallery;
 
   // System settings current values
   int get captureDelaySecondsSetting => getIt<SettingsManager>().settings.captureDelaySeconds;


### PR DESCRIPTION
## What

Adds a `showGallery` project setting (default: `true`) that lets an operator hide the gallery from guests.

When disabled:
- the **Gallery** button is removed from the navigation screen;
- the **Gallery** item is hidden from the menu bar.

## Why

Some events don't want guests browsing (and re-printing/sharing) previously captured photos of other people. Today the gallery is always reachable. This adds an opt-out per project.

## Notes

- Default `true` → **no behaviour change** for existing projects.
- Project-scoped (saved in the project directory), consistent with the other capture/UI project settings.
- New toggle lives under *Settings → Project → UI settings for project*.
- UI strings are hardcoded English, consistent with the rest of that settings page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)