### PR TITLE
Add per-project toggle to show/hide the 'Get QR' button

### DIFF
--- a/lib/models/project_settings.dart
+++ b/lib/models/project_settings.dart
@@ -33,6 +33,7 @@ sealed class ProjectSettings with _$ProjectSettings implements TomlEncodableValu
     @Default(CollageMode.userSelection) CollageMode collageMode,
     @Default(Language.noLanguage) Language language,
     @Default([]) List<Language> availableLanguages,
+    @Default(true) bool showGetQrButton,
   }) = _ProjectSettings;
 
   factory ProjectSettings.withDefaults() => ProjectSettings.fromJson({});

--- a/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_view.dart
+++ b/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_view.dart
@@ -75,18 +75,19 @@ class PhotoDetailsScreenView extends ScreenViewBase<PhotoDetailsScreenViewModel,
   Widget _getBottomRow() {
     return Row(
       children: [
-        Flexible(
-          child: Center(
-            child: PhotoBoothButton.action(
-              onPressed: controller.onClickGetQR,
-              child: AutoSizeTextAndIcon(
-                text: localizations.photoDetailsScreenGetQrButton,
-                leftIcon: LucideIcons.scanQrCode,
-                autoSizeGroup: controller.actionButtonGroup,
+        if (viewModel.showGetQrButton)
+          Flexible(
+            child: Center(
+              child: PhotoBoothButton.action(
+                onPressed: controller.onClickGetQR,
+                child: AutoSizeTextAndIcon(
+                  text: localizations.photoDetailsScreenGetQrButton,
+                  leftIcon: LucideIcons.scanQrCode,
+                  autoSizeGroup: controller.actionButtonGroup,
+                ),
               ),
             ),
           ),
-        ),
         Flexible(
           child: Center(
             child: Observer(

--- a/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_view_model.dart
+++ b/lib/views/photo_booth_screen/screens/photo_details_screen/photo_details_screen_view_model.dart
@@ -29,6 +29,7 @@ abstract class PhotoDetailsScreenViewModelBase extends ScreenViewModelBase with 
   });
 
   Directory get outputDir => getIt<ProjectManager>().getOutputDir();
+  bool get showGetQrButton => getIt<ProjectManager>().settings.showGetQrButton;
   File? get file => File(path.join(outputDir.path, photoId));
   Future<List<MomentoBoothExifTag>> get metadata async => await getMomentoBoothExifTagsFromFile(imageFilePath: file!.path);
   Future<GalleryImage> get galleryImage async => GalleryImage(file: file!, exifTags: await metadata);

--- a/lib/views/photo_booth_screen/screens/share_screen/share_screen_view.dart
+++ b/lib/views/photo_booth_screen/screens/share_screen/share_screen_view.dart
@@ -119,16 +119,17 @@ class ShareScreenView extends ScreenViewBase<ShareScreenViewModel, ShareScreenCo
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceAround,
       children: [
-        Flexible(
-          child: PhotoBoothButton.action(
-            onPressed: controller.onClickGetQR,
-            child: AutoSizeTextAndIcon(
-              text: localizations.photoDetailsScreenGetQrButton,
-              leftIcon: LucideIcons.scanQrCode,
-              autoSizeGroup: controller.actionButtonGroup,
+        if (viewModel.showGetQrButton)
+          Flexible(
+            child: PhotoBoothButton.action(
+              onPressed: controller.onClickGetQR,
+              child: AutoSizeTextAndIcon(
+                text: localizations.photoDetailsScreenGetQrButton,
+                leftIcon: LucideIcons.scanQrCode,
+                autoSizeGroup: controller.actionButtonGroup,
+              ),
             ),
           ),
-        ),
         Flexible(
           child: Observer(
             builder: (context) => PhotoBoothButton.action(

--- a/lib/views/photo_booth_screen/screens/share_screen/share_screen_view_model.dart
+++ b/lib/views/photo_booth_screen/screens/share_screen/share_screen_view_model.dart
@@ -26,6 +26,7 @@ abstract class ShareScreenViewModelBase extends ScreenViewModelBase with Store {
   });
 
   bool get displayConfetti => getIt<ProjectManager>().settings.displayConfetti;
+  bool get showGetQrButton => getIt<ProjectManager>().settings.showGetQrButton;
   late final ConfettiController confettiController = ConfettiController(duration: const Duration(milliseconds: 100))..play();
 
   Uint8List get outputImage => getIt<PhotosManager>().outputImage!;

--- a/lib/views/settings_overlay/pages/settings_overlay_view.project.dart
+++ b/lib/views/settings_overlay/pages/settings_overlay_view.project.dart
@@ -77,6 +77,13 @@ Widget _getProjectSettings(SettingsOverlayViewModel viewModel, SettingsOverlayCo
                 value: () => viewModel.projectAvailableLanguagesSetting,
                 onChanged: controller.onProjectAvailableLanguagesChanged,
               ),
+              SettingsToggleTile(
+                icon: LucideIcons.qrCode,
+                title: "Show ‘Get QR’ button",
+                subtitle: "If enabled, the ‘Get QR’ button is shown on the share and photo detail screens so users can download their photo. Disable this if online sharing is not used.",
+                value: () => viewModel.showGetQrButtonSetting,
+                onChanged: controller.onShowGetQrButtonChanged,
+              ),
             ]
           );
         }

--- a/lib/views/settings_overlay/settings_overlay_controller.dart
+++ b/lib/views/settings_overlay/settings_overlay_controller.dart
@@ -214,6 +214,12 @@ class SettingsOverlayController extends ScreenControllerBase<SettingsOverlayView
     }
   }
 
+  void onShowGetQrButtonChanged(bool? showGetQrButton) {
+    if (showGetQrButton != null) {
+      viewModel.updateProjectSettings((settings) => settings.copyWith(showGetQrButton: showGetQrButton));
+    }
+  }
+
   void onEnableWakelockChanged(bool? enableWakelock) {
     if (enableWakelock != null) {
       viewModel.updateSettings((settings) => settings.copyWith(enableWakelock: enableWakelock));

--- a/lib/views/settings_overlay/settings_overlay_view_model.dart
+++ b/lib/views/settings_overlay/settings_overlay_view_model.dart
@@ -221,6 +221,7 @@ abstract class SettingsOverlayViewModelBase extends ScreenViewModelBase with Sto
   Color get primaryColorSetting => getIt<ProjectManager>().settings.primaryColor;
   Language get projectLanguageSetting => getIt<ProjectManager>().settings.language;
   List<Language> get projectAvailableLanguagesSetting => getIt<ProjectManager>().settings.availableLanguages;
+  bool get showGetQrButtonSetting => getIt<ProjectManager>().settings.showGetQrButton;
 
   // System settings current values
   int get captureDelaySecondsSetting => getIt<SettingsManager>().settings.captureDelaySeconds;


### PR DESCRIPTION
## What

Adds a `showGetQrButton` project setting (default: `true`) that hides the **Get QR** button when disabled, on both:
- the **share screen** (after a capture), and
- the **photo detail** screen (gallery reprint).

## Why

QR sharing relies on an `ffsend` server being configured. For events that don't use online sharing, the button currently still shows and leads nowhere. This lets an operator turn it off per project.

## Notes

- Default `true` → **no behaviour change** for existing projects.
- Project-scoped, saved in the project directory.
- New toggle lives under *Settings → Project → UI settings for project*.
- UI strings are hardcoded English, consistent with the rest of that settings page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)